### PR TITLE
Support installation of scoped modules

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -39,7 +39,7 @@ module.exports = function fetch (dir, tarball, shasum, log) {
 
     function finish () {
       var digest = actualShasum.digest('hex')
-      debug('finish %s %s', shasum, tarball);
+      debug('finish %s %s', shasum, tarball)
       if (shasum && digest !== shasum) {
         return reject(new Error('' + tarball + ': incorrect shasum (expected ' + shasum + ', got ' + digest + ')'))
       }

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -39,7 +39,7 @@ module.exports = function fetch (dir, tarball, shasum, log) {
 
     function finish () {
       var digest = actualShasum.digest('hex')
-      debug('finish %s', shasum)
+      debug('finish %s %s', shasum, tarball);
       if (shasum && digest !== shasum) {
         return reject(new Error('' + tarball + ': incorrect shasum (expected ' + shasum + ', got ' + digest + ')'))
       }

--- a/lib/install.js
+++ b/lib/install.js
@@ -74,12 +74,12 @@ module.exports = function install (ctx, pkg, modules, options) {
             pkgData.dependencies,
             join(paths.tmp, 'node_modules'),
             { depth: depth + 1 }))
-          .then(_ => symlinkSelf(paths.tmp, name, depth))
+          .then(_ => symlinkSelf(paths.tmp, pkgSpec, depth))
           .then(_ => fs.rename(paths.tmp, paths.target))
           .then(_ => unlock(ctx, paths.target))
         })
         .then(_ => mkdirp(modules))
-        .then(_ => symlinkToModules(paths.target, name, modules))
+        .then(_ => symlinkToModules(paths.target, pkgSpec, modules))
     })
     .then(_ => log('done'))
     .catch(err => {
@@ -90,7 +90,7 @@ module.exports = function install (ctx, pkg, modules, options) {
   // set metadata as fetched from resolve()
   function set (res) {
     pkgData = res
-    fullname = '' + res.name + '@' + res.version
+    fullname = '' + res.name.replace('/', '!') + '@' + res.version
     paths.target = join(paths.store, fullname)
     name = res.name
     dist = res.dist
@@ -115,14 +115,15 @@ function isLocked (ctx, path) {
  * require('babel-runtime') within itself.
  */
 
-function symlinkSelf (target, name, depth) {
+function symlinkSelf (target, pkg, depth) {
+  debug('symlinkSelf %s', pkg.name)
   if (depth === 0) {
     return Promise.resolve()
   } else {
     return mkdirp(join(target, 'node_modules'))
       .then(_ => symlink(
         join('..'),
-        join(target, 'node_modules', name)))
+        join(target, 'node_modules', pkg.name)))
   }
 }
 
@@ -135,9 +136,15 @@ function symlinkSelf (target, name, depth) {
  *     symlinkToModules(fullname, name, modules, 0)
  */
 
-function symlinkToModules (target, name, modules) {
+function symlinkToModules (target, pkg, modules) {
   // lodash -> .store/lodash@4.0.0
   // .store/foo@1.0.0/node_modules/lodash -> ../../../.store/lodash@4.0.0
   // .tmp/01234567890/node_modules/lodash -> ../../../.store/lodash@4.0.0
-  return relSymlink(target, join(modules, name))
+  if (pkg.scope) {
+    debug('make scope dir', pkg.scope)
+    return fs.mkdir(join(modules, pkg.scope))
+      .then(relSymlink(target, join(modules, pkg.name)))
+  }
+
+  return relSymlink(target, join(modules, pkg.name))
 }


### PR DESCRIPTION
This PR does the following:

1. Installation of scoped modules. All scoped modules will be installed into `node_modules/.store/@{scope}!{name}@{version}` 
2. Pass `pkgSpec` to more methods. 
3. More debugging: 
  - add `tarball` to `finish` debug message to match shasums to tarball fetches.
  - Debug `symlinkSelf`.