### PR TITLE
[WIP] First pass at attempting to resolve `latest` for scoped modules

### DIFF
--- a/lib/latest.js
+++ b/lib/latest.js
@@ -1,0 +1,46 @@
+var join = require('path').join
+var url = require('url')
+var enc = global.encodeURIComponent
+var got = require('./got')
+var config = require('./config')
+
+module.exports = function (pkg) {
+  // { raw: 'rimraf@2', scope: null, name: 'rimraf', rawSpec: '2' || '' }
+  return Promise.resolve()
+    .then(_ => toUri(pkg))
+    .then(ver => {
+      console.log(ver);
+    })
+    // .then(url => got(url))
+    // .then(res => {
+    //   var body = JSON.parse(res.body)
+    //   return body['dist-tags'].latest;
+    // })
+    .catch(errify)
+
+  function errify (err) {
+    if (err.statusCode === 404) {
+      throw new Error("Module '" + pkg.raw + "' not found")
+    }
+    throw err
+  }
+}
+
+/**
+ * Converts package data (from `npa()`) to a URI
+ *
+ *     toUri({ name: 'rimraf', rawSpec: '2' })
+ *     // => 'https://registry.npmjs.org/rimraf/2'
+ */
+
+function toUri (pkg) {
+  var name
+
+  if (pkg.name.substr(0, 1) === '@') {
+    name = '@' + enc(pkg.name.substr(1))
+  } else {
+    name = enc(pkg.name)
+  }
+
+  return url.resolve(config.registry, name)
+}

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -3,6 +3,7 @@ var url = require('url')
 var enc = global.encodeURIComponent
 var got = require('./got')
 var config = require('./config')
+var latest = require('./latest')
 
 /**
  * Resolves a package in the NPM registry. Done as part of `install()`.
@@ -43,9 +44,22 @@ module.exports = function resolve (pkg) {
  */
 
 function toUri (pkg) {
-  // TODO: handle scoped packages
   var name, uri
 
+  if (pkg.scope && pkg.spec === 'latest') {
+    return Promise.resolve()
+      .then(latest(pkg))
+      .then(function (version) {
+        console.dir(arguments);
+        pkg.rawSpec = version;
+        return unscopedUri(pkg)
+      })
+  }
+
+  return unscopedUri(pkg)
+}
+
+function unscopedUri (pkg) {
   if (pkg.name.substr(0, 1) === '@') {
     name = '@' + enc(pkg.name.substr(1))
   } else {

--- a/test/latest.js
+++ b/test/latest.js
@@ -1,0 +1,19 @@
+
+var test = require('tape')
+var latest = require('../lib/latest')
+
+test('@rstacruz/tap-spec', function (t) {
+  var pkg = {
+    raw: '@rstacruz/tap-spec',
+    scope: '@rstacruz',
+    name: '@rstacruz/tap-spec',
+    rawSpec: '',
+    spec: 'latest',
+    type: 'tag'
+  }
+
+  latest(pkg).then(function (latest) {
+    t.equal(latest, '4.1.1')
+    t.end()
+  })
+});


### PR DESCRIPTION
:warning: This is not currently working :warning: 

@rstacruz this is where I got on this. Just define a method that can get the latest version if you have to and then use that only for scoped modules when the `pkg.spec` is `latest`. Can't get it working for some reason, but thought you might take a stab at it.