### PR TITLE
Refactor install.js

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -35,17 +35,18 @@ var fs = require('mz/fs')
  */
 
 module.exports = function install (ctx, pkg, modules, options) {
-  var installAll = require('./install_multiple')
   debug('installing ' + pkg)
 
-  var depth = (options && options.depth || 0)
+  var keypath = (options && options.keypath || [])
   var pkgSpec = npa(pkg) // { raw, name, scope, type, spec, rawSpec }
   var pkgData  // { name, version, ... }
   var fullname // 'lodash@4.0.0'
   var dist     // { shasum, tarball }
   var log = ctx.log(pkgSpec) // function
+  if (!ctx.fetches) ctx.fetches = {}
 
   var paths = {
+    modules: modules,
     store: join(ctx.root, 'node_modules', '.store'),
     tmp: join(ctx.root, 'node_modules', '.tmp', getUuid()),
     target: undefined // store + '/lodash@4.0.0'
@@ -60,25 +61,11 @@ module.exports = function install (ctx, pkg, modules, options) {
         .then(_ => fs.stat(join(paths.target, 'package.json'))) // todo: verify version?
         .catch(err => {
           if (err.code !== 'ENOENT') throw err
-          if (isLocked(ctx, paths.target)) return Promise.resolve()
-          return Promise.resolve()
-          .then(_ => lock(ctx, paths.target))
-          .then(_ => log('downloading'))
-          .then(_ => mkdirp(paths.store))
-          .then(_ => mkdirp(paths.tmp))
-          .then(_ => fetch(paths.tmp, dist.tarball, dist.shasum, log))
-          .then(_ => linkBins(modules, paths.tmp, paths.target))
-          .then(_ => log('dependencies'))
-          .then(_ => installAll(ctx,
-            pkgData.dependencies,
-            join(paths.tmp, 'node_modules'),
-            { depth: depth + 1 }))
-          .then(_ => symlinkSelf(paths.tmp, pkgSpec, depth))
-          .then(_ => fs.rename(paths.tmp, paths.target))
-          .then(_ => unlock(ctx, paths.target))
+          return memoize(ctx.fetches, paths.target,
+            _ => doFetch(ctx, paths, dist, pkgData, keypath.concat(fullname), log))
         })
-        .then(_ => mkdirp(modules))
-        .then(_ => symlinkToModules(paths.target, pkgSpec, modules))
+        .then(_ => mkdirp(paths.modules))
+        .then(_ => symlinkToModules(paths.target, pkgSpec, paths.modules))
     })
     .then(_ => log('done'))
     .catch(err => {
@@ -95,17 +82,29 @@ module.exports = function install (ctx, pkg, modules, options) {
   }
 }
 
-function lock (ctx, path) {
-  if (!ctx.lock) ctx.lock = {}
-  ctx.lock[path] = true
+// perform a fetch to `.store/lodash@4.0.0` (paths.target)
+function doFetch (ctx, paths, dist, pkgData, keypath, log) {
+  var installAll = require('./install_multiple')
+
+  return Promise.resolve()
+    .then(_ => log('downloading'))
+    .then(_ => mkdirp(paths.store))
+    .then(_ => mkdirp(paths.tmp))
+    .then(_ => fetch(paths.tmp, dist.tarball, dist.shasum, log))
+    .then(_ => linkBins(paths.modules, paths.tmp, paths.target))
+    .then(_ => log('dependencies'))
+    .then(_ => installAll(ctx,
+      pkgData.dependencies,
+      join(paths.tmp, 'node_modules'),
+      { keypath: keypath }))
+    .then(_ => symlinkSelf(paths.tmp, pkgData, keypath.length - 1))
+    .then(_ => fs.rename(paths.tmp, paths.target))
 }
 
-function unlock (ctx, path) {
-  if (ctx.lock) ctx.lock[path] = undefined
-}
-
-function isLocked (ctx, path) {
-  return ctx.lock && ctx.lock[path]
+function memoize (locks, key, fn) {
+  if (locks && locks[key]) return locks[key]
+  locks[key] = fn()
+  return locks[key]
 }
 
 /*

--- a/lib/install.js
+++ b/lib/install.js
@@ -35,43 +35,60 @@ var fs = require('mz/fs')
  * - symlink bins
  */
 
-module.exports = function install (ctx, pkg, modules, options) {
-  debug('installing ' + pkg)
-
-  var keypath = (options && options.keypath || [])
-  var pkgSpec = npa(pkg) // { raw, name, scope, type, spec, rawSpec }
-  var pkgData  // { name, version, ... }
-  var fullname // 'lodash@4.0.0'
-  var dist     // { shasum, tarball }
-  var log = ctx.log(pkgSpec) // function
+module.exports = function install (ctx, pkgSpec, modules, options) {
+  debug('installing ' + pkgSpec)
   if (!ctx.fetches) ctx.fetches = {}
 
-  var paths = {
-    modules: modules,
-    store: join(ctx.root, 'node_modules', '.store'),
-    tmp: join(ctx.root, 'node_modules', '.tmp', getUuid()),
-    target: undefined // store + '/lodash@4.0.0'
+  var pkg = {
+    // Preliminary spec data
+    // => { raw, name, scope, type, spec, rawSpec }
+    spec: npa(pkgSpec),
+
+    // Dependency path to the current package
+    // => ['babel-core@6.4.5', 'babylon@6.4.5', 'babel-runtime@5.8.35']
+    keypath: (options && options.keypath || []),
+
+    // Full name of package => 'lodash@4.0.0'
+    fullname: undefined,
+
+    // Distribution data from resolve() => { shasum, tarball }
+    dist: undefined,
+
+    // package.json data as retrieved from resolve() => { name, version, ... }
+    data: undefined
   }
 
-  return fs.stat(join(modules, pkgSpec.name, 'package.json'))
+  var paths = {
+    modules: modules, // './node_modules'
+
+    // Final destination
+    store: join(ctx.root, 'node_modules', '.store'),
+
+    // Temporary destination while building
+    tmp: join(ctx.root, 'node_modules', '.tmp', getUuid()),
+
+    // Final destination => store + '/lodash@4.0.0'
+    target: undefined
+  }
+
+  var log = ctx.log(pkg.spec) // function
+
+  return fs.stat(join(modules, pkg.spec.name, 'package.json'))
     .catch(err => {
       if (err.code !== 'ENOENT') throw err
-      return resolve(pkgSpec)
+      return resolve(pkg.spec)
         .then(set)
-        .then(_ => log('resolved', pkgData))
+        .then(_ => log('resolved', pkg.data))
         .then(_ => fs.stat(join(paths.target, 'package.json'))) // todo: verify version?
         .catch(err => {
           if (err.code !== 'ENOENT') throw err
-          var isCircular = keypath.indexOf(fullname) > -1
-          if (isCircular) {
-            return Promise.resolve()
-          } else {
-            return memoize(ctx.fetches, fullname,
-              _ => doFetch(ctx, paths, dist, pkgData, keypath.concat(fullname), log))
-          }
+          return isCircular(pkg)
+            ? Promise.resolve()
+            : memoize(ctx.fetches, pkg.fullname,
+              _ => doFetch(ctx, paths, pkg, log))
         })
         .then(_ => mkdirp(paths.modules))
-        .then(_ => symlinkToModules(paths.target, pkgSpec, paths.modules))
+        .then(_ => symlinkToModules(paths.target, pkg.spec, paths.modules))
     })
     .then(_ => log('done'))
     .catch(err => {
@@ -81,15 +98,15 @@ module.exports = function install (ctx, pkg, modules, options) {
 
   // set metadata as fetched from resolve()
   function set (res) {
-    pkgData = res
-    fullname = '' + res.name.replace('/', '!') + '@' + res.version
-    paths.target = join(paths.store, fullname)
-    dist = res.dist
+    pkg.data = res
+    pkg.fullname = '' + res.name.replace('/', '!') + '@' + res.version
+    pkg.dist = res.dist
+    paths.target = join(paths.store, pkg.fullname)
   }
 }
 
 // perform a fetch to `.store/lodash@4.0.0` (paths.target)
-function doFetch (ctx, paths, dist, pkgData, keypath, log) {
+function doFetch (ctx, paths, pkg, log) {
   var installAll = require('./install_multiple')
 
   return Promise.resolve()
@@ -98,14 +115,14 @@ function doFetch (ctx, paths, dist, pkgData, keypath, log) {
     .then(_ => log('downloading'))
     .then(_ => mkdirp(paths.store))
     .then(_ => mkdirp(paths.tmp))
-    .then(_ => fetch(paths.tmp, dist.tarball, dist.shasum, log))
+    .then(_ => fetch(paths.tmp, pkg.dist.tarball, pkg.dist.shasum, log))
     .then(_ => linkBins(paths.modules, paths.tmp, paths.target))
     .then(_ => log('dependencies'))
     .then(_ => installAll(ctx,
-      pkgData.dependencies,
+      pkg.data.dependencies,
       join(paths.tmp, 'node_modules'),
-      { keypath: keypath }))
-    .then(_ => symlinkSelf(paths.tmp, pkgData, keypath.length - 1))
+      { keypath: pkg.keypath.concat([ pkg.fullname ]) }))
+    .then(_ => symlinkSelf(paths.tmp, pkg.data, pkg.keypath.length))
     .then(_ => fs.unlink(paths.target))
     .then(_ => fs.rename(paths.tmp, paths.target))
 }
@@ -153,4 +170,12 @@ function symlinkToModules (target, pkg, modules) {
   }
 
   return relSymlink(target, join(modules, pkg.name))
+}
+
+/*
+ * Checks if the current package is a circular dependency.
+ */
+
+function isCircular (pkg) {
+  return pkg.keypath.indexOf(pkg.fullname) > -1
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -2,6 +2,7 @@ var Promise = require('./promise')
 var debug = require('debug')('pnpm:install')
 var npa = require('npm-package-arg')
 var join = require('path').join
+var dirname = require('path').dirname
 var mkdirp = require('./mkdirp')
 var fetch = require('./fetch')
 var resolve = require('./resolve')
@@ -61,8 +62,13 @@ module.exports = function install (ctx, pkg, modules, options) {
         .then(_ => fs.stat(join(paths.target, 'package.json'))) // todo: verify version?
         .catch(err => {
           if (err.code !== 'ENOENT') throw err
-          return memoize(ctx.fetches, paths.target,
-            _ => doFetch(ctx, paths, dist, pkgData, keypath.concat(fullname), log))
+          var isCircular = keypath.indexOf(fullname) > -1
+          if (isCircular) {
+            return Promise.resolve()
+          } else {
+            return memoize(ctx.fetches, fullname,
+              _ => doFetch(ctx, paths, dist, pkgData, keypath.concat(fullname), log))
+          }
         })
         .then(_ => mkdirp(paths.modules))
         .then(_ => symlinkToModules(paths.target, pkgSpec, paths.modules))
@@ -87,6 +93,8 @@ function doFetch (ctx, paths, dist, pkgData, keypath, log) {
   var installAll = require('./install_multiple')
 
   return Promise.resolve()
+    .then(_ => mkdirp(dirname(paths.target)))
+    .then(_ => symlink(paths.tmp, paths.target))
     .then(_ => log('downloading'))
     .then(_ => mkdirp(paths.store))
     .then(_ => mkdirp(paths.tmp))
@@ -98,6 +106,7 @@ function doFetch (ctx, paths, dist, pkgData, keypath, log) {
       join(paths.tmp, 'node_modules'),
       { keypath: keypath }))
     .then(_ => symlinkSelf(paths.tmp, pkgData, keypath.length - 1))
+    .then(_ => fs.unlink(paths.target))
     .then(_ => fs.rename(paths.tmp, paths.target))
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -37,7 +37,7 @@ var fs = require('mz/fs')
 
 module.exports = function install (ctx, pkgSpec, modules, options) {
   debug('installing ' + pkgSpec)
-  if (!ctx.fetches) ctx.fetches = {}
+  if (!ctx.builds) ctx.builds = {}
 
   var pkg = {
     // Preliminary spec data
@@ -59,7 +59,8 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   }
 
   var paths = {
-    modules: modules, // './node_modules'
+    // Module storage => './node_modules'
+    modules: modules,
 
     // Final destination
     store: join(ctx.root, 'node_modules', '.store'),
@@ -73,23 +74,14 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
 
   var log = ctx.log(pkg.spec) // function
 
-  return fs.stat(join(modules, pkg.spec.name, 'package.json'))
-    .catch(err => {
-      if (err.code !== 'ENOENT') throw err
-      return resolve(pkg.spec)
-        .then(set)
+  return make(join(modules, pkg.spec.name), _ =>
+      resolve(pkg.spec)
+        .then(saveResolution)
         .then(_ => log('resolved', pkg.data))
-        .then(_ => fs.stat(join(paths.target, 'package.json'))) // todo: verify version?
-        .catch(err => {
-          if (err.code !== 'ENOENT') throw err
-          return isCircular(pkg)
-            ? Promise.resolve()
-            : memoize(ctx.fetches, pkg.fullname,
-              _ => doFetch(ctx, paths, pkg, log))
-        })
+        .then(_ => make(paths.target, _ =>
+          buildToStoreCached(ctx, paths, pkg, log)))
         .then(_ => mkdirp(paths.modules))
-        .then(_ => symlinkToModules(paths.target, pkg.spec, paths.modules))
-    })
+        .then(_ => symlinkToModules(paths.target, pkg.spec, paths.modules)))
     .then(_ => log('done'))
     .catch(err => {
       log('error', err)
@@ -97,7 +89,7 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
     })
 
   // set metadata as fetched from resolve()
-  function set (res) {
+  function saveResolution (res) {
     pkg.data = res
     pkg.fullname = '' + res.name.replace('/', '!') + '@' + res.version
     pkg.dist = res.dist
@@ -105,32 +97,59 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   }
 }
 
-// perform a fetch to `.store/lodash@4.0.0` (paths.target)
-function doFetch (ctx, paths, pkg, log) {
+/*
+ * Builds to `.store/lodash@4.0.0` (paths.target)
+ * If an ongoing build is already working, use it. Also, if that ongoing build
+ * is part of the dependency chain (ie, it's a circular dependency), use its stub
+ */
+
+function buildToStoreCached (ctx, paths, pkg, log) {
+  if (isCircular(pkg)) {
+    return Promise.resolve()
+  } else {
+    return memoize(ctx.builds, pkg.fullname, _ =>
+      buildToStore(ctx, paths, pkg, log))
+  }
+}
+
+/*
+ * Builds to `.store/lodash@4.0.0` (paths.target)
+ * Fetches from npm, recurses to dependencies, runs lifecycle scripts, etc
+ */
+
+function buildToStore (ctx, paths, pkg, log) {
   var installAll = require('./install_multiple')
 
   return Promise.resolve()
+    // symlink .tmp/0a1b2c3d -> .store/lodash@4.0.0
+    // so that when any other module requires it, it's available even
+    // if it's partially built
     .then(_ => mkdirp(dirname(paths.target)))
     .then(_ => symlink(paths.tmp, paths.target))
+
+    // download and untar
     .then(_ => log('downloading'))
     .then(_ => mkdirp(paths.store))
     .then(_ => mkdirp(paths.tmp))
     .then(_ => fetch(paths.tmp, pkg.dist.tarball, pkg.dist.shasum, log))
+
+    // link node_modules/.bin
     .then(_ => linkBins(paths.modules, paths.tmp, paths.target))
+
+    // recurse down to dependencies
     .then(_ => log('dependencies'))
     .then(_ => installAll(ctx,
       pkg.data.dependencies,
       join(paths.tmp, 'node_modules'),
       { keypath: pkg.keypath.concat([ pkg.fullname ]) }))
+
+    // symlink itself; . -> node_modules/lodash@4.0.0
+    // this way it can require itself
     .then(_ => symlinkSelf(paths.tmp, pkg.data, pkg.keypath.length))
+
+    // move to .store/lodash@4.0.0; remove the stub done earlier
     .then(_ => fs.unlink(paths.target))
     .then(_ => fs.rename(paths.tmp, paths.target))
-}
-
-function memoize (locks, key, fn) {
-  if (locks && locks[key]) return locks[key]
-  locks[key] = fn()
-  return locks[key]
 }
 
 /*
@@ -178,4 +197,27 @@ function symlinkToModules (target, pkg, modules) {
 
 function isCircular (pkg) {
   return pkg.keypath.indexOf(pkg.fullname) > -1
+}
+
+/*
+ * If `path` exists, don't do anything; otherwise invoke `fn()`.
+ * Kinda like how makefiles work.
+ */
+
+function make (path, fn) {
+  return fs.stat(path)
+  .catch(err => {
+    if (err.code !== 'ENOENT') throw err
+    return fn()
+  })
+}
+
+/*
+ * Save promises for later
+ */
+
+function memoize (locks, key, fn) {
+  if (locks && locks[key]) return locks[key]
+  locks[key] = fn()
+  return locks[key]
 }

--- a/test/index.js
+++ b/test/index.js
@@ -68,7 +68,7 @@ test('idempotency (rimraf)', function (t) {
   }, t.end)
 })
 
-test('big with dependencies (babel-preset-2015)', function (t) {
+test('big with dependencies and circular deps (babel-preset-2015)', function (t) {
   prepare()
   install({ input: ['babel-preset-es2015@6.3.13'], flags: { quiet: true } })
   .then(function () {


### PR DESCRIPTION
This is an initial stab at refactoring install.js to support future versions.

Biggest functional change is that while a module is still building, it's available as `.store/lodash@4.0.0` _as a symlink_ to `.tmp/0a1b2c3d...` — this way, for modules that are circular dependencies, its sub-modules can already use it. This will come in handy later when we support lifecycle scripts which will require a modules dependencies to be fully-functional before running `preinstall` / `install` / `postinstall`.
