### PR TITLE
Bundle dependencies

### DIFF
--- a/lib/got.js
+++ b/lib/got.js
@@ -31,7 +31,7 @@ function extend (options) {
   if (!options) options = {}
   return assign({}, options, {
     headers: assign({}, options.headers || {}, {
-      'user-agent': 'https://github.com/rstacruz'
+      'user-agent': 'https://github.com/rstacruz/pnpm.js'
     })
   })
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -193,7 +193,7 @@ function symlinkToModules (target, pkg, modules) {
   if (pkg.scope) {
     debug('make scope dir', pkg.scope)
     return mkdirp(join(modules, pkg.scope))
-      .then(relSymlink(target, join(modules, pkg.name)))
+      .then(_ => relSymlink(target, join(modules, pkg.name)))
   }
 
   return relSymlink(target, join(modules, pkg.name))

--- a/lib/install.js
+++ b/lib/install.js
@@ -10,6 +10,7 @@ var getUuid = require('node-uuid')
 var symlink = require('./force_symlink')
 var relSymlink = require('./rel_symlink')
 var linkBins = require('./install/link_bins')
+var linkBundledDeps = require('./install/link_bundled_deps')
 var fs = require('mz/fs')
 
 /*
@@ -55,7 +56,10 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
     dist: undefined,
 
     // package.json data as retrieved from resolve() => { name, version, ... }
-    data: undefined
+    data: undefined,
+
+    // package.json data as retrieved from actual package
+    fulldata: undefined
   }
 
   var paths = {
@@ -133,8 +137,12 @@ function buildToStore (ctx, paths, pkg, log) {
     .then(_ => mkdirp(paths.tmp))
     .then(_ => fetch(paths.tmp, pkg.dist.tarball, pkg.dist.shasum, log))
 
+    // update pkg.fulldata; to be used later
+    .then(_ => { pkg.fulldata = require(join(paths.tmp, 'package.json')) })
+
     // link node_modules/.bin
     .then(_ => linkBins(paths.modules, paths.tmp, paths.target))
+    .then(_ => linkBundledDeps(paths.tmp))
 
     // recurse down to dependencies
     .then(_ => log('dependencies'))

--- a/lib/install/link_bins.js
+++ b/lib/install/link_bins.js
@@ -2,6 +2,7 @@ var join = require('path').join
 var relSymlink = require('../rel_symlink')
 var fs = require('mz/fs')
 var mkdirp = require('../mkdirp')
+var debug = require('debug')('pnpm:link_bins')
 
 /*
  * Links executables into `node_modules/.bin`.
@@ -30,8 +31,11 @@ module.exports = function linkBins (modules, target, finalTarget) {
     return Promise.resolve()
       .then(_ => fs.chmod(join(target, actualBin), 0o755))
       .then(_ => mkdirp(join(modules, '.bin')))
+      .then(_ => debug('linking %s -> %s',
+        join(finalTarget, actualBin),
+        join(modules, '.bin', bin)))
       .then(_ => relSymlink(
-        finalTarget,
+        join(finalTarget, actualBin),
         join(modules, '.bin', bin)))
   })
 }

--- a/lib/install/link_bundled_deps.js
+++ b/lib/install/link_bundled_deps.js
@@ -1,0 +1,29 @@
+var Promise = require('../promise')
+var fs = require('mz/fs')
+var join = require('path').join
+var linkBins = require('./link_bins')
+
+module.exports = function linkBundledDeps (root) {
+  var nodeModules = join(root, 'node_modules')
+
+  return isDir(nodeModules, _ =>
+    Promise.all(fs.readdir(nodeModules).map(mod =>
+      isDir(join(nodeModules, mod), _ =>
+        symlinkBundledDep(nodeModules, join(nodeModules, mod))
+      )
+    )))
+}
+
+function symlinkBundledDep (nodeModules, submod) {
+  return linkBins(nodeModules, submod, submod)
+}
+
+function isDir (path, fn) {
+  return fs.stat(path)
+  .then(stat => {
+    if (!stat.isDirectory()) return Promise.resolve()
+    return fn()
+  })
+  .catch(err => { if (err.code !== 'ENOENT') throw err })
+}
+

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,2 +1,2 @@
-global.Promise = global.Promise || require('bluebird')
+global.Promise = require('bluebird')
 module.exports = global.Promise

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/rstacruz/pnpm/issues"
   },
   "dependencies": {
+    "bluebird": "3.1.5",
     "chalk": "1.1.1",
     "commondir": "1.0.1",
     "debug": "2.2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ var stat
 
 test('eslint', require('tape-eslint')())
 
-test.only('small with dependencies (rimraf)', function (t) {
+test('small with dependencies (rimraf)', function (t) {
   prepare()
   install({ input: ['rimraf@2.5.1'], flags: { quiet: true } })
   .then(function () {

--- a/test/support/sepia.js
+++ b/test/support/sepia.js
@@ -1,3 +1,2 @@
 process.env.VCR_MODE = 'cache'
 require('sepia')
-


### PR DESCRIPTION
This adds support for binstubs of bundled dependencies.

This is crucial to make packages like fsevents work, which has `node-pre-gyp` as its `bundleDependencies`, which it expects to run as a postinstall script.

Now, if you do `pnpm install fsevents`, it will add the correct binstubs for its bundled dependencies (eg, `node_modules/fsevents/node_modules/.bin/mkdirp`).

It also makes pnpm use bluebird by default now. This gets us better debugging in development (just `export BLUEBIRD_DEBUG=1`), as well as more reliable Promise.all support.