### PR TITLE
Improve atomicness

### DIFF
--- a/lib/fs/obliterate.js
+++ b/lib/fs/obliterate.js
@@ -1,0 +1,23 @@
+require('../promise')
+var rimraf = require('thenify')(require('rimraf'))
+var fs = require('mz/fs')
+
+/*
+ * Removes `path`.
+ * If it's a symlink, remove its destination as well.
+ */
+
+module.exports = function obliterate (path) {
+  return fs.lstat(path)
+    .then(stat => {
+      if (stat.isSymbolicLink()) {
+        return fs.readlink(path)
+          .then(realpath => rimraf(realpath))
+      } else {
+        return rimraf(path)
+      }
+    })
+    .catch(err => {
+      if (err !== 'ENOENT') throw err
+    })
+}

--- a/lib/install.js
+++ b/lib/install.js
@@ -12,7 +12,7 @@ var relSymlink = require('./rel_symlink')
 var linkBins = require('./install/link_bins')
 var linkBundledDeps = require('./install/link_bundled_deps')
 var fs = require('mz/fs')
-var rimraf = require('thenify')(require('rimraf'))
+var obliterate = require('./fs/obliterate')
 
 /*
  * Installs a package.
@@ -221,7 +221,7 @@ function make (path, isWorking, fn) {
   return fs.stat(path)
   .then(_ => {
     return fs.stat(join(path, '.pnpm_inprogress'))
-    .then(_ => { if (!isWorking) return rimraf(path).then(fn) })
+    .then(_ => { if (!isWorking) return obliterate(path).then(fn) })
     .catch(err => { if (err.code !== 'ENOENT') throw err })
   })
   .catch(err => {

--- a/lib/install.js
+++ b/lib/install.js
@@ -12,6 +12,7 @@ var relSymlink = require('./rel_symlink')
 var linkBins = require('./install/link_bins')
 var linkBundledDeps = require('./install/link_bundled_deps')
 var fs = require('mz/fs')
+var rimraf = require('thenify')(require('rimraf'))
 
 /*
  * Installs a package.
@@ -78,12 +79,11 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
 
   var log = ctx.log(pkg.spec) // function
 
-  return make(join(modules, pkg.spec.name), _ =>
+  return make(join(modules, pkg.spec.name), false, _ =>
       resolve(pkg.spec)
         .then(saveResolution)
         .then(_ => log('resolved', pkg.data))
-        .then(_ => make(paths.target, _ =>
-          buildToStoreCached(ctx, paths, pkg, log)))
+        .then(_ => buildToStoreCached(ctx, paths, pkg, log))
         .then(_ => mkdirp(paths.modules))
         .then(_ => symlinkToModules(paths.target, pkg.spec, paths.modules)))
     .then(_ => log('done'))
@@ -111,8 +111,9 @@ function buildToStoreCached (ctx, paths, pkg, log) {
   if (isCircular(pkg)) {
     return Promise.resolve()
   } else {
-    return memoize(ctx.builds, pkg.fullname, _ =>
-      buildToStore(ctx, paths, pkg, log))
+    return make(paths.target, ctx.builds[pkg.fullname], _ =>
+      memoize(ctx.builds, pkg.fullname, _ =>
+        buildToStore(ctx, paths, pkg, log)))
   }
 }
 
@@ -135,6 +136,7 @@ function buildToStore (ctx, paths, pkg, log) {
     .then(_ => log('downloading'))
     .then(_ => mkdirp(paths.store))
     .then(_ => mkdirp(paths.tmp))
+    .then(_ => fs.writeFile(join(paths.tmp, '.pnpm_inprogress'), '', 'utf-8'))
     .then(_ => fetch(paths.tmp, pkg.dist.tarball, pkg.dist.shasum, log))
 
     // update pkg.fulldata; to be used later
@@ -156,6 +158,7 @@ function buildToStore (ctx, paths, pkg, log) {
     .then(_ => symlinkSelf(paths.tmp, pkg.data, pkg.keypath.length))
 
     // move to .store/lodash@4.0.0; remove the stub done earlier
+    .then(_ => fs.unlink(join(paths.tmp, '.pnpm_inprogress')))
     .then(_ => fs.unlink(paths.target))
     .then(_ => fs.rename(paths.tmp, paths.target))
 }
@@ -208,12 +211,19 @@ function isCircular (pkg) {
 }
 
 /*
- * If `path` exists, don't do anything; otherwise invoke `fn()`.
- * Kinda like how makefiles work.
+ * If `path` doesn't exist, run `fn()`.
+ * If it exists and is not in progress, don't do anything.
+ * If it's in progress, check if we're working on it. If we're not,
+ * obliterate it and run `fn()`.
  */
 
-function make (path, fn) {
+function make (path, isWorking, fn) {
   return fs.stat(path)
+  .then(_ => {
+    return fs.stat(join(path, '.pnpm_inprogress'))
+    .then(_ => { if (!isWorking) return rimraf(path).then(fn) })
+    .catch(err => { if (err.code !== 'ENOENT') throw err })
+  })
   .catch(err => {
     if (err.code !== 'ENOENT') throw err
     return fn()


### PR DESCRIPTION
In practice, this allows you to interrupt `pnpm install`, then run it again, and it'll work just fine after that... no matter where you stopped it.

- This makes `pnpm` installs into `.store` atomic. That is, if it's in `.store` and `.store/lodash@4.0.0/.pnpm_inprogress` is not present, you're sure that it's an incomplete installation of a module.
- With that, this adds `.pnpm_inprogress` to modules that are currently in progress in being built. It's cleaned up afterwards.
- `node_modules/.tmp` is cleaned up afterwards. There's no explicit handling to `rm -rf .tmp` or anything (that'd be awful!)—simply, if pnpm tries to rebuild a module that has `.pnpm_inprogress` (ie, from a broken install), it'll know to tear the old `.tmp` version of that down. Neat.

### Why .pnpm_inprogress?
Note that since 0.5.0, pnpm symlinks partial installs from `.tmp/0a1b2c3d...` into `.store/lodash@4.0.0`. This allows you to use `lodash@4.0.0` while it's being built—sadly something needed by modules that have circular dependencies (ehem, `babel-core`). Hence, you can't count on the existence of `.store/lodash@4.0.0` as a way to determine that `lodash@4.0.0` is built.

An empty `.pnpm_inprogress` file solves that. As long as that file is present, it means it's a transient package that's in the middle of being built.