### PR TITLE
Improve bundleDependencies support

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -87,14 +87,21 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
 
   var log = ctx.log(pkg.spec) // function
 
-  return resolve(pkg.spec)
-    .then(saveResolution)
-    .then(_ => log('resolved', pkg))
-    .then(_ => make(join(modules, pkg.spec.name), false, _ =>
-      Promise.resolve()
-        .then(_ => buildToStoreCached(ctx, paths, pkg, log))
-        .then(_ => mkdirp(paths.modules))
-        .then(_ => symlinkToModules(paths.target, paths.modules))))
+  // it might be a bundleDependency, in which case, don't bother
+  return isBundled(pkg.spec.name, modules, {
+    then: _ => {
+      paths.target = join(modules, pkg.spec.name)
+    },
+    else: _ =>
+      resolve(pkg.spec)
+        .then(saveResolution)
+        .then(_ => log('resolved', pkg))
+        .then(_ => make(join(modules, pkg.spec.name), false, _ =>
+          Promise.resolve()
+            .then(_ => buildToStoreCached(ctx, paths, pkg, log))
+            .then(_ => mkdirp(paths.modules))
+            .then(_ => symlinkToModules(paths.target, paths.modules))))
+  })
 
     // package.json data isn't logged if it was already installed before,
     // so do it again to be sure. it's not always available though
@@ -117,6 +124,23 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
     pkg.dist = res.dist
     paths.target = join(ctx.store, res.fullname)
   }
+}
+
+/*
+ * Check if a module exists (eg, `node_modules/node-pre-gyp`). This is the case when
+ * it's part of bundleDependencies.
+ */
+
+function isBundled (name, modules, run) {
+  if (!name) return run.else && run.else()
+
+  return Promise.resolve()
+    .then(_ => fs.statSync(join(modules, name, 'package.json')))
+    .then(_ => run.then && run.then())
+    .catch(err => {
+      if (err.code !== 'ENOENT') throw err
+      return run.else && run.else()
+    })
 }
 
 /*

--- a/lib/install.js
+++ b/lib/install.js
@@ -89,12 +89,21 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
 
   return resolve(pkg.spec)
     .then(saveResolution)
-    .then(_ => log('resolved', pkg.fullname))
+    .then(_ => log('resolved', pkg))
     .then(_ => make(join(modules, pkg.spec.name), false, _ =>
       Promise.resolve()
         .then(_ => buildToStoreCached(ctx, paths, pkg, log))
         .then(_ => mkdirp(paths.modules))
         .then(_ => symlinkToModules(paths.target, paths.modules))))
+
+    // package.json data isn't logged if it was already installed before,
+    // so do it again to be sure. it's not always available though
+    .then(_ => {
+      try {
+        return log('package.json', requireJson(join(paths.target, 'package.json')))
+      } catch (e) { } })
+
+    // done
     .then(_ => log('done'))
     .catch(err => {
       log('error', err)
@@ -104,6 +113,7 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   // set metadata as fetched from resolve()
   function saveResolution (res) {
     pkg.fullname = res.fullname
+    pkg.version = res.version
     pkg.dist = res.dist
     paths.target = join(ctx.store, res.fullname)
   }
@@ -160,6 +170,7 @@ function buildInStore (ctx, paths, pkg, log) {
 
   return Promise.resolve()
     .then(_ => { fulldata = requireJson(abspath(join(paths.tmp, 'package.json'))) })
+    .then(_ => log('package.json', fulldata))
 
     // link node_modules/.bin
     .then(_ => linkBins(paths.modules, paths.tmp, paths.target))

--- a/lib/install.js
+++ b/lib/install.js
@@ -124,6 +124,9 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
 /*
  * Check if a module exists (eg, `node_modules/node-pre-gyp`). This is the case when
  * it's part of bundleDependencies.
+ *
+ * This check is also responsible for stopping `pnpm i lodash` from doing anything when
+ * 'node_modules/lodash' already exists.
  */
 
 function isBundled (name, modules, run) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -90,7 +90,7 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   return make(join(modules, pkg.spec.name), false, _ =>
       resolve(pkg.spec)
         .then(saveResolution)
-        .then(_ => log('resolved', pkg.data))
+        .then(_ => log('resolved', pkg.fullname))
         .then(_ => buildToStoreCached(ctx, paths, pkg, log))
         .then(_ => mkdirp(paths.modules))
         .then(_ => symlinkToModules(paths.target, paths.modules)))
@@ -102,10 +102,9 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
 
   // set metadata as fetched from resolve()
   function saveResolution (res) {
-    pkg.data = res
-    pkg.fullname = '' + res.name.replace('/', '!') + '@' + res.version
+    pkg.fullname = res.fullname
     pkg.dist = res.dist
-    paths.target = join(ctx.store, pkg.fullname)
+    paths.target = join(ctx.store, res.fullname)
   }
 }
 
@@ -168,13 +167,13 @@ function buildInStore (ctx, paths, pkg, log) {
     // recurse down to dependencies
     .then(_ => log('dependencies'))
     .then(_ => installAll(ctx,
-      pkg.data.dependencies,
+      fulldata.dependencies,
       join(paths.tmp, 'node_modules'),
       { keypath: pkg.keypath.concat([ pkg.fullname ]) }))
 
     // symlink itself; . -> node_modules/lodash@4.0.0
     // this way it can require itself
-    .then(_ => symlinkSelf(paths.tmp, pkg.data, pkg.keypath.length))
+    .then(_ => symlinkSelf(paths.tmp, fulldata, pkg.keypath.length))
 
     // postinstall hooks
     .then(_ => postInstall(paths.tmp, fulldata, installLogger(log, pkg)))

--- a/lib/install.js
+++ b/lib/install.js
@@ -87,13 +87,14 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
 
   var log = ctx.log(pkg.spec) // function
 
-  return make(join(modules, pkg.spec.name), false, _ =>
-      resolve(pkg.spec)
-        .then(saveResolution)
-        .then(_ => log('resolved', pkg.fullname))
+  return resolve(pkg.spec)
+    .then(saveResolution)
+    .then(_ => log('resolved', pkg.fullname))
+    .then(_ => make(join(modules, pkg.spec.name), false, _ =>
+      Promise.resolve()
         .then(_ => buildToStoreCached(ctx, paths, pkg, log))
         .then(_ => mkdirp(paths.modules))
-        .then(_ => symlinkToModules(paths.target, paths.modules)))
+        .then(_ => symlinkToModules(paths.target, paths.modules))))
     .then(_ => log('done'))
     .catch(err => {
       log('error', err)

--- a/lib/install.js
+++ b/lib/install.js
@@ -96,19 +96,14 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
       resolve(pkg.spec)
         .then(saveResolution)
         .then(_ => log('resolved', pkg))
-        .then(_ => make(join(modules, pkg.spec.name), false, _ =>
-          Promise.resolve()
-            .then(_ => buildToStoreCached(ctx, paths, pkg, log))
-            .then(_ => mkdirp(paths.modules))
-            .then(_ => symlinkToModules(paths.target, paths.modules))))
+        .then(_ => buildToStoreCached(ctx, paths, pkg, log))
+        .then(_ => mkdirp(paths.modules))
+        .then(_ => symlinkToModules(paths.target, paths.modules))
   })
 
     // package.json data isn't logged if it was already installed before,
-    // so do it again to be sure. it's not always available though
-    .then(_ => {
-      try {
-        return log('package.json', requireJson(join(paths.target, 'package.json')))
-      } catch (e) { } })
+    // so do it again to be sure.
+    .then(_ => { log('package.json', requireJson(join(paths.target, 'package.json'))) })
 
     // done
     .then(_ => log('done'))

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -5,7 +5,8 @@ observatory.settings({ prefix: '  ', width: 74 })
 
 module.exports = function logger () {
   return function (pkg) {
-    var pkgData
+    var pkgData // package.json
+    var res // resolution
 
     var t = observatory.add(pkg.name + ' ' +
       chalk.gray(pkg.rawSpec || ''))
@@ -19,9 +20,13 @@ module.exports = function logger () {
     // log('error', err)
     function status (status, args) {
       if (status === 'resolved') {
-        pkgData = args
+        res = args
       } else if (status === 'downloading') {
-        t.status(chalk.yellow('downloading ' + pkgData.version + ' ·'))
+        if (res.version) {
+          t.status(chalk.yellow('downloading ' + res.version + ' ·'))
+        } else {
+          t.status(chalk.yellow('downloading ·'))
+        }
         if (args && args.total && args.done < args.total) {
           t.details('' + Math.round(args.done / args.total * 100) + '%')
         } else {
@@ -35,6 +40,8 @@ module.exports = function logger () {
           t.status(chalk.green('OK ✓'))
             .details('')
         }
+      } else if (status === 'package.json') {
+        pkgData = args
       } else if (status === 'dependencies') {
         t.status(chalk.gray('' + pkgData.version + ' ·'))
           .details('')

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -1,8 +1,4 @@
-var join = require('path').join
-var url = require('url')
-var enc = global.encodeURIComponent
-var got = require('./got')
-var config = require('./config')
+var resolveNpm = require('./resolve/npm')
 
 /**
  * Resolves a package in the NPM registry. Done as part of `install()`.
@@ -10,8 +6,7 @@ var config = require('./config')
  *     var npa = require('npm-package-arg')
  *     resolve(npa('rimraf@2'))
  *       .then((res) => {
- *         res.name == 'rimraf'
- *         res.version == '2.5.1'
+ *         res.fullname == 'rimraf@2.5.1'
  *         res.dist == {
  *           shasum: '0a1b2c...'
  *           tarball: 'http://...'
@@ -20,58 +15,9 @@ var config = require('./config')
  */
 
 module.exports = function resolve (pkg) {
-  // { raw: 'rimraf@2', scope: null, name: 'rimraf', rawSpec: '2' || '' }
-  return Promise.resolve()
-    .then(_ => toUri(pkg))
-    .then(url => got(url))
-    .then(res => JSON.parse(res.body))
-    .then(res => {
-      return {
-        fullname: '' + res.name.replace('/', '!') + '@' + res.version,
-        dist: res.dist
-      }
-    })
-    .catch(errify)
-
-  function errify (err) {
-    if (err.statusCode === 404) {
-      throw new Error("Module '" + pkg.raw + "' not found")
-    }
-    throw err
-  }
-}
-
-/**
- * Converts package data (from `npa()`) to a URI
- *
- *     toUri({ name: 'rimraf', rawSpec: '2' })
- *     // => 'https://registry.npmjs.org/rimraf/2'
- */
-
-function toUri (pkg) {
-  // TODO: handle scoped packages
-  var name, uri
-
-  if (pkg.name.substr(0, 1) === '@') {
-    name = '@' + enc(pkg.name.substr(1))
+  if (pkg.type === 'range' || pkg.type === 'version' || pkg.type === 'tag') {
+    return resolveNpm(pkg)
   } else {
-    name = enc(pkg.name)
+    throw new Error('' + pkg + ': ' + pkg.type + ' packages not supported')
   }
-
-  if (pkg.rawSpec.length) {
-    uri = join(name, enc(pkg.rawSpec))
-  } else {
-    if (pkg.name.substr(0, 1) === '@') {
-      // the npm registry doesn't support resolutions of dist tags of scoped packages.
-      // This means you can't do `pnpm install @rstacruz/tap-spec` or `pnpm
-      // install @rstacruz/tap-spec@latest`. As a workaround, we'll use.
-      // OK - https://registry.npmjs.org/@rstacruz%2Ftap-spec/*
-      // Nope - https://registry.npmjs.org/@rstacruz%2Ftap-spec/latest
-      uri = join(name, '*')
-    } else {
-      uri = join(name, 'latest')
-    }
-  }
-
-  return url.resolve(config.registry, uri)
 }

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -25,6 +25,12 @@ module.exports = function resolve (pkg) {
     .then(_ => toUri(pkg))
     .then(url => got(url))
     .then(res => JSON.parse(res.body))
+    .then(res => {
+      return {
+        fullname: '' + res.name.replace('/', '!') + '@' + res.version,
+        dist: res.dist
+      }
+    })
     .catch(errify)
 
   function errify (err) {

--- a/lib/resolve/npm.js
+++ b/lib/resolve/npm.js
@@ -1,0 +1,76 @@
+var join = require('path').join
+var url = require('url')
+var enc = global.encodeURIComponent
+var got = require('../got')
+var config = require('../config')
+
+/**
+ * Resolves a package in the NPM registry. Done as part of `install()`.
+ *
+ *     var npa = require('npm-package-arg')
+ *     resolve(npa('rimraf@2'))
+ *       .then((res) => {
+ *         res.fullname == 'rimraf@2.5.1'
+ *         res.dist == {
+ *           shasum: '0a1b2c...'
+ *           tarball: 'http://...'
+ *         }
+ *       })
+ */
+
+module.exports = function resolveNpm (pkg) {
+  // { raw: 'rimraf@2', scope: null, name: 'rimraf', rawSpec: '2' || '' }
+  return Promise.resolve()
+    .then(_ => toUri(pkg))
+    .then(url => got(url))
+    .then(res => JSON.parse(res.body))
+    .then(res => {
+      return {
+        fullname: '' + res.name.replace('/', '!') + '@' + res.version,
+        dist: res.dist
+      }
+    })
+    .catch(errify)
+
+  function errify (err) {
+    if (err.statusCode === 404) {
+      throw new Error("Module '" + pkg.raw + "' not found")
+    }
+    throw err
+  }
+}
+
+/**
+ * Converts package data (from `npa()`) to a URI
+ *
+ *     toUri({ name: 'rimraf', rawSpec: '2' })
+ *     // => 'https://registry.npmjs.org/rimraf/2'
+ */
+
+function toUri (pkg) {
+  // TODO: handle scoped packages
+  var name, uri
+
+  if (pkg.name.substr(0, 1) === '@') {
+    name = '@' + enc(pkg.name.substr(1))
+  } else {
+    name = enc(pkg.name)
+  }
+
+  if (pkg.rawSpec.length) {
+    uri = join(name, enc(pkg.rawSpec))
+  } else {
+    if (pkg.name.substr(0, 1) === '@') {
+      // the npm registry doesn't support resolutions of dist tags of scoped packages.
+      // This means you can't do `pnpm install @rstacruz/tap-spec` or `pnpm
+      // install @rstacruz/tap-spec@latest`. As a workaround, we'll use.
+      // OK - https://registry.npmjs.org/@rstacruz%2Ftap-spec/*
+      // Nope - https://registry.npmjs.org/@rstacruz%2Ftap-spec/latest
+      uri = join(name, '*')
+    } else {
+      uri = join(name, 'latest')
+    }
+  }
+
+  return url.resolve(config.registry, uri)
+}

--- a/lib/resolve/npm.js
+++ b/lib/resolve/npm.js
@@ -27,6 +27,7 @@ module.exports = function resolveNpm (pkg) {
     .then(res => {
       return {
         fullname: '' + res.name.replace('/', '!') + '@' + res.version,
+        version: res.version, // used for displaying
         dist: res.dist
       }
     })


### PR DESCRIPTION
This better stops pnpm from doing anything when a sub-package is already bundled in a package, typically using `bundleDependencies`. This happens in `fsevents@1.0.6` where `node-pre-gyp` is already part of the `fsevents` package.

This also refactors `lib/resolve.js` a bit so that tarball/github resolution can be better implemented in the future.