### PR TITLE
Fix running pnpm in dirs without package.json

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+## [v0.10.1]
+> Jan 30, 2016
+
+- [#33] - Fix instances of running pnpm in directories without package.json.
+
+[v0.10.1]: https://github.com/rstacruz/pnpm/compare/v0.10.0...v0.10.1
+
 ## [v0.10.0]
 > Jan 30, 2016
 

--- a/bin/pnpm-install
+++ b/bin/pnpm-install
@@ -82,7 +82,7 @@ function run (cli) {
   }
 
   function updateContext (packageJson) {
-    var root = dirname(packageJson)
+    var root = packageJson ? dirname(packageJson) : process.cwd()
     ctx.root = root
     ctx.store = join(root, 'node_modules', '.store')
     if (!cli.flags.quiet) ctx.log = logger()

--- a/lib/fs/require_json.js
+++ b/lib/fs/require_json.js
@@ -7,6 +7,12 @@ var cache = {}
 module.exports = function requireJson (path) {
   path = require('path').resolve(path)
   if (cache[path]) return cache[path]
-  cache[path] = JSON.parse(require('fs').readFileSync(path, 'utf-8'))
+  try {
+    cache[path] = JSON.parse(require('fs').readFileSync(path, 'utf-8'))
+  } catch (e) {
+    console.error('')
+    console.error('' + e.stack)
+    process.exit(1)
+  }
   return cache[path]
 }

--- a/lib/install/post_install.js
+++ b/lib/install/post_install.js
@@ -8,7 +8,7 @@ var byline = require('byline')
 var fs = require('mz/fs')
 
 module.exports = function postInstall (root, pkg, log) {
-  debug('postinstall', pkg)
+  debug('postinstall', pkg.name + '@' + pkg.version)
   var scripts = pkg && pkg.scripts || {}
   return Promise.resolve()
     .then(_ => !scripts.install && checkBindingGyp(root, log))
@@ -35,7 +35,7 @@ function checkBindingGyp (root, log) {
  */
 
 function runScript (root, script, log) {
-  debug('runscript', script)
+  if (script) debug('runscript', script)
   if (!script) return Promise.resolve()
   return new Promise((resolve, reject) => {
     var env = Object.create(process.env)


### PR DESCRIPTION
This fixes running `pnpm install express` in a path where there's no package.json.