### PR TITLE
Custom registries (#10)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 > Jan 31, 2016
 
 - [#24], [#34] - Limit download concurrency.
+- [#10], [#35] - Allow custom registries.
 
 [v0.11.0]: https://github.com/rstacruz/pnpm/compare/v0.10.1...v0.11.0
 
@@ -121,6 +122,8 @@
 - Initial preview release.
 
 [v0.1.0]: https://github.com/rstacruz/pnpm/blob/v0.1.0
+[#9]: https://github.com/rstacruz/pnpm/issues/9
+[#10]: https://github.com/rstacruz/pnpm/issues/10
 [#11]: https://github.com/rstacruz/pnpm/issues/11
 [#16]: https://github.com/rstacruz/pnpm/issues/16
 [#17]: https://github.com/rstacruz/pnpm/issues/17
@@ -129,6 +132,6 @@
 [#25]: https://github.com/rstacruz/pnpm/issues/25
 [#31]: https://github.com/rstacruz/pnpm/issues/31
 [#34]: https://github.com/rstacruz/pnpm/issues/34
-[#9]: https://github.com/rstacruz/pnpm/issues/9
+[#35]: https://github.com/rstacruz/pnpm/issues/35
 [@indexzero]: https://github.com/indexzero
 [@rstacruz]: https://github.com/rstacruz

--- a/README.md
+++ b/README.md
@@ -22,6 +22,28 @@ Use `pnpm` in place of `npm`. It overrides `pnpm i` and `pnpm install`—all oth
 pnpm install lodash
 ```
 
+## Custom registries
+
+pnpm follows whatever is configured as npm registries. To use a custom registry (like the [strongloop npm registry](https://strongloop.com/strongblog/node-js-registry-mirror-rackspace/)), use:
+
+```sh
+# updates ~/.npmrc
+npm config set registry http://npmjs.eu
+```
+
+Or to use it for just one command:
+
+```
+env npm_registry=http://npmjs.eu
+```
+
+Private registries are supported, as well.
+
+```sh
+npm config set @mycompany:registry https://npm.mycompany.com
+pnpm install @mycompany/foo
+```
+
 ## Preview release
 
 `pnpm` will stay in `<1.0.0` until it's achieved feature parity with `npm install`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,3 @@
 module.exports = require('rc')('pnpm', {
-  registry: 'https://registry.npmjs.org/',
   concurrency: 16
 })

--- a/lib/registry_for.js
+++ b/lib/registry_for.js
@@ -1,0 +1,13 @@
+var registryUrl = require('registry-url')
+
+/*
+ * Returns the registry needed for a certain package.
+ */
+
+module.exports = function registryFor (pkg) {
+  if (pkg.substr(0, 1) === '@') {
+    return registryUrl(pkg.split('/')[0])
+  } else {
+    return registryUrl()
+  }
+}

--- a/lib/resolve/npm.js
+++ b/lib/resolve/npm.js
@@ -2,7 +2,7 @@ var join = require('path').join
 var url = require('url')
 var enc = global.encodeURIComponent
 var got = require('../got')
-var config = require('../config')
+var registryFor = require('../registry_for')
 
 /**
  * Resolves a package in the NPM registry. Done as part of `install()`.
@@ -73,5 +73,5 @@ function toUri (pkg) {
     }
   }
 
-  return url.resolve(config.registry, uri)
+  return url.resolve(registryFor(pkg.name), uri)
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "observatory": "1.0.0",
     "rc": "1.1.6",
     "read-pkg-up": "1.0.1",
+    "registry-url": "3.0.3",
     "rimraf": "2.5.1",
     "semver": "5.1.0",
     "tar-fs": "1.9.0",


### PR DESCRIPTION
> ## Custom registries
> 
> pnpm follows whatever is configured as npm registries. To use a custom registry (like the [strongloop npm registry](https://strongloop.com/strongblog/node-js-registry-mirror-rackspace/)), use:
> 
> ```sh
> # updates ~/.npmrc
> npm config set registry http://npmjs.eu
> ```
> 
> Or to use it for just one command:
> 
> ```
> env npm_registry=http://npmjs.eu
> ```
> 
> Private registries are supported, as well.
> 
> ```sh
> npm config set @mycompany:registry https://npm.mycompany.com
> pnpm install @mycompany/foo
> ```
