### PR TITLE
Work around scoped module limitations

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+## [v0.11.1]
+> Jan 31, 2016
+
+- [#9], [#36] - Support exact versions in scoped packages (`pnpm i @rstacruz/tap-spec@4.1.1`).
+
+[v0.11.1]: https://github.com/rstacruz/pnpm/compare/v0.11.0...v0.11.1
+
 ## [v0.11.0]
 > Jan 31, 2016
 
@@ -135,5 +142,6 @@
 [#33]: https://github.com/rstacruz/pnpm/issues/33
 [#34]: https://github.com/rstacruz/pnpm/issues/34
 [#35]: https://github.com/rstacruz/pnpm/issues/35
+[#36]: https://github.com/rstacruz/pnpm/issues/36
 [@indexzero]: https://github.com/indexzero
 [@rstacruz]: https://github.com/rstacruz

--- a/lib/resolve/npm.js
+++ b/lib/resolve/npm.js
@@ -58,20 +58,35 @@ function toUri (pkg) {
     name = enc(pkg.name)
   }
 
-  if (pkg.rawSpec.length) {
-    uri = join(name, enc(pkg.rawSpec))
+  if (pkg.name.substr(0, 1) === '@') {
+    uri = join(name, scopeWorkarounds(pkg))
   } else {
-    if (pkg.name.substr(0, 1) === '@') {
-      // the npm registry doesn't support resolutions of dist tags of scoped packages.
-      // This means you can't do `pnpm install @rstacruz/tap-spec` or `pnpm
-      // install @rstacruz/tap-spec@latest`. As a workaround, we'll use.
-      // OK - https://registry.npmjs.org/@rstacruz%2Ftap-spec/*
-      // Nope - https://registry.npmjs.org/@rstacruz%2Ftap-spec/latest
-      uri = join(name, '*')
-    } else {
-      uri = join(name, 'latest')
-    }
+    uri = join(name, pkg.spec)
   }
 
   return url.resolve(registryUrl(pkg.scope), uri)
+}
+
+/*
+ * The npm registry doesn't support resolutions of dist tags of scoped
+ * packages, or exact versions... only ranges. This means you can't do `pnpm
+ * install @rstacruz/tap-spec` or `pnpm install @rstacruz/tap-spec@latest`.
+ *
+ * As a workaround, we'll use `*` for `latest`. And for exact versions,
+ * we'll convert them to a range (`=2.0.0`).
+ *
+ * OK   - https://registry.npmjs.org/@rstacruz%2Ftap-spec/*
+ * Nope - https://registry.npmjs.org/@rstacruz%2Ftap-spec/latest
+ */
+
+function scopeWorkarounds (pkg) {
+  if (pkg.type === 'tag' && pkg.spec === 'latest') {
+    return '*'
+  } else if (pkg.type === 'version') {
+    return '=' + pkg.spec
+  } else if (pkg.type === 'range') {
+    return pkg.spec
+  } else {
+    throw new Error('Unsupported for now: ' + pkg.raw)
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,16 @@ test('scoped modules without version spec (@rstacruz/tap-spec)', function (t) {
   }, t.end)
 })
 
+test('scoped modules with versions (@rstacruz/tap-spec@4.1.1)', function (t) {
+  prepare()
+  install({ input: ['@rstacruz/tap-spec@4.1.1'], flags: { quiet: true } })
+  .then(function () {
+    var _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+    t.ok(typeof _ === 'function', 'tap-spec is available')
+    t.end()
+  }, t.end)
+})
+
 test('scoped modules (@rstacruz/tap-spec@*)', function (t) {
   prepare()
   install({ input: ['@rstacruz/tap-spec@*'], flags: { quiet: true } })


### PR DESCRIPTION
This allows you to do:

```
pnpm i @rstacruz/tap-spec@4.1.1
```

We'll do a proper implementation soon (#12), but for now... this'll do. (#9)