### PR TITLE
Increase compatibility with npm ls & shrinkwrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
 - '4'
-cache:
-  directories:
-  - node_modules
-  - fixtures
+# cache:
+#   directories:
+#   - node_modules
+#   - fixtures
 env:
   - CC=clang CXX=clang++ npm_config_clang=1

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,16 @@
+## [v0.12.0]
+> Jan 31, 2016
+
+- **Semi-breaking** - store format was slightly changed. pnpm will continue to be compatible with the old store format, but rebuilding `node_modules` is recommended to take advantage of new features.
+- [#38] - Allow compatibility with npm utilities:
+  - npm dedupe
+  - npm shrinkwrap
+  - npm prune
+  - npm ls
+  - npm rebuild
+
+[v0.12.0]: https://github.com/rstacruz/pnpm/compare/v0.11.1...v0.12.0
+
 ## [v0.11.1]
 > Jan 31, 2016
 
@@ -143,5 +156,6 @@
 [#34]: https://github.com/rstacruz/pnpm/issues/34
 [#35]: https://github.com/rstacruz/pnpm/issues/35
 [#36]: https://github.com/rstacruz/pnpm/issues/36
+[#38]: https://github.com/rstacruz/pnpm/issues/38
 [@indexzero]: https://github.com/indexzero
 [@rstacruz]: https://github.com/rstacruz

--- a/README.md
+++ b/README.md
@@ -74,14 +74,22 @@ To illustrate, an installation of [chalk][]@1.1.1 may look like this:
    ├─ .store/
    │  ├─ chalk@1.1.1/
    │  │  └─ node_modules/
-   │  │     ├─ ansi-styles      -> ../../ansi-styles@2.1.0
-   │  │     ├─ has-ansi         -> ../../has-ansi@2.0.0
-   │  │     └─ supports-color   -> ../../supports-color@2.0.0
+   │  │     ├─ ansi-styles      -> ../../ansi-styles@2.1.0/_
+   │  │     ├─ has-ansi         -> ../../has-ansi@2.0.0/_
+   │  │     └─ supports-color   -> ../../supports-color@2.0.0/_
    │  ├─ ansi-styles@2.1.0/
+   │  │  ├─ _/
+   │  │  └─ node_modules/
    │  ├─ has-ansi@2.0.0/
+   │  │  ├─ _/
+   │  │  └─ node_modules/
    │  └─ supports-color@2.0.0/
-   └─ chalk                     -> .store/chalk@1.1.1
+   │     ├─ _/
+   │     └─ node_modules/
+   └─ chalk                     -> .store/chalk@1.1.1/_
 ```
+
+The intermediate `_` directories are needed to hide `node_modules` from npm utilities like `npm ls`, `npm prune`, `npm shrinkwrap` and so on. The name `_` is chosen because it helps make stack traces readable.
 
 [chalk]: https://github.com/chalk/chalk
 
@@ -103,15 +111,15 @@ Unlike ied, however:
 
 - `pnpm` will eventually be made to support a globally-shared store so you can keep all your npm modules in one place. With this goal in mind, `pnpm` also doesn't care much about `npm@3`'s flat dependency tree style.
 - pnpm also supports circular dependencies.
+- pnpm aims to achieve compatibility with npm utilities (eg, shrinkwrap), and so deviates from ied's store schema (see [§ Design](#design)).
 
 [ied]: https://github.com/alexanderGugel/ied
 
 ## Limitations
 
-- Windows is [not supported](https://github.com/rstacruz/pnpm/issues/6).
-- You can't [shrinkwrap][].
-- `node_modules` managed by pnpm can't be queried properly by [npm ls][].
-- You can't use [npm prune][] or [npm dedupe][].
+- Windows is [not supported](https://github.com/rstacruz/pnpm/issues/6) (yet).
+- You can't [shrinkwrap][] (yet).
+- You can't use [npm prune][] or [npm dedupe][] (yet?).
 - Things not ticked off in the [to do list](#preview-release) are obviously not feature-complete.
 
 Got an idea for workarounds for these issues? [Share them.](https://github.com/rstacruz/pnpm/issues/new)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pnpm install @mycompany/foo
   - [ ] `--global` installs
   - [ ] `--save` et al
 - [ ] `pnpm uninstall`
-- [ ] `pnpm ls`
+- [x] `pnpm ls`
 
 ## Design
 

--- a/lib/fs/require_json.js
+++ b/lib/fs/require_json.js
@@ -7,12 +7,6 @@ var cache = {}
 module.exports = function requireJson (path) {
   path = require('path').resolve(path)
   if (cache[path]) return cache[path]
-  try {
-    cache[path] = JSON.parse(require('fs').readFileSync(path, 'utf-8'))
-  } catch (e) {
-    console.error('')
-    console.error('' + e.stack)
-    process.exit(1)
-  }
+  cache[path] = JSON.parse(require('fs').readFileSync(path, 'utf-8'))
   return cache[path]
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -94,12 +94,12 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
         .then(_ => log('resolved', pkg))
         .then(_ => buildToStoreCached(ctx, paths, pkg, log))
         .then(_ => mkdirp(paths.modules))
-        .then(_ => symlinkToModules(paths.target, paths.modules))
+        .then(_ => symlinkToModules(join(paths.target, '_'), paths.modules))
   })
 
     // package.json data isn't logged if it was already installed before,
     // so do it again to be sure.
-    .then(_ => { log('package.json', requireJson(join(paths.target, 'package.json'))) })
+    .then(_ => { log('package.json', requireJson(join(paths.target, '_', 'package.json'))) })
 
     // done
     .then(_ => log('done'))
@@ -173,9 +173,9 @@ function fetchToStore (ctx, paths, pkg, log) {
     // download and untar
     .then(_ => log('downloading'))
     .then(_ => mkdirp(ctx.store))
-    .then(_ => mkdirp(paths.tmp))
+    .then(_ => mkdirp(join(paths.tmp, '_')))
     .then(_ => fs.writeFile(join(paths.tmp, '.pnpm_inprogress'), '', 'utf-8'))
-    .then(_ => fetch(paths.tmp, pkg.dist.tarball, pkg.dist.shasum, log))
+    .then(_ => fetch(join(paths.tmp, '_'), pkg.dist.tarball, pkg.dist.shasum, log))
 
     // TODO: this is the point it becomes partially useable.
     // ie, it can now be symlinked into .store/foo@1.0.0.
@@ -187,7 +187,7 @@ function buildInStore (ctx, paths, pkg, log) {
   var fulldata
 
   return Promise.resolve()
-    .then(_ => { fulldata = requireJson(abspath(join(paths.tmp, 'package.json'))) })
+    .then(_ => { fulldata = requireJson(abspath(join(paths.tmp, '_', 'package.json'))) })
     .then(_ => log('package.json', fulldata))
 
     // link node_modules/.bin
@@ -233,7 +233,7 @@ function symlinkSelf (target, pkg, depth) {
   } else {
     return mkdirp(join(target, 'node_modules'))
       .then(_ => symlink(
-        join('..'),
+        join('..', '_'),
         join(target, 'node_modules', pkg.name)))
   }
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -96,6 +96,7 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
         .then(_ => buildToStoreCached(ctx, paths, pkg, log))
         .then(_ => mkdirp(paths.modules))
         .then(_ => symlinkToModules(join(paths.target, '_'), paths.modules))
+        .then(_ => log('package.json', requireJson(join(paths.target, '_', 'package.json'))))
   })
     // done
     .then(_ => log('done'))

--- a/lib/install.js
+++ b/lib/install.js
@@ -87,6 +87,7 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   return isBundled(pkg.spec.name, modules, {
     then: _ => {
       paths.target = join(modules, pkg.spec.name)
+      log('package.json', requireJson(join(paths.target, 'package.json')))
     },
     else: _ =>
       resolve(pkg.spec)
@@ -96,11 +97,6 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
         .then(_ => mkdirp(paths.modules))
         .then(_ => symlinkToModules(join(paths.target, '_'), paths.modules))
   })
-
-    // package.json data isn't logged if it was already installed before,
-    // so do it again to be sure.
-    .then(_ => { log('package.json', requireJson(join(paths.target, '_', 'package.json'))) })
-
     // done
     .then(_ => log('done'))
     .catch(err => {

--- a/lib/install.js
+++ b/lib/install.js
@@ -194,7 +194,7 @@ function buildInStore (ctx, paths, pkg, log) {
     .then(_ => log('dependencies'))
     .then(_ => installAll(ctx,
       fulldata.dependencies,
-      join(paths.tmp, 'node_modules'),
+      join(paths.tmp, '_', 'node_modules'),
       { keypath: pkg.keypath.concat([ pkg.fullname ]) }))
 
     // symlink itself; . -> node_modules/lodash@4.0.0

--- a/lib/install.js
+++ b/lib/install.js
@@ -187,8 +187,8 @@ function buildInStore (ctx, paths, pkg, log) {
     .then(_ => log('package.json', fulldata))
 
     // link node_modules/.bin
-    .then(_ => linkBins(paths.modules, paths.tmp, paths.target))
-    .then(_ => linkBundledDeps(paths.tmp))
+    .then(_ => linkBins(paths.modules, join(paths.tmp, '_'), join(paths.target, '_')))
+    .then(_ => linkBundledDeps(join(paths.tmp, '_')))
 
     // recurse down to dependencies
     .then(_ => log('dependencies'))

--- a/lib/install/link_bins.js
+++ b/lib/install/link_bins.js
@@ -20,7 +20,7 @@ var debug = require('debug')('pnpm:link_bins')
  */
 
 module.exports = function linkBins (modules, target, finalTarget) {
-  var pkg = tryRequire(join(target, '_', 'package.json'))
+  var pkg = tryRequire(join(target, 'package.json'))
   if (!pkg || !pkg.bin) return
 
   var bins = binify(pkg)
@@ -29,13 +29,13 @@ module.exports = function linkBins (modules, target, finalTarget) {
     var actualBin = bins[bin]
 
     return Promise.resolve()
-      .then(_ => fs.chmod(join(target, '_', actualBin), 0o755))
+      .then(_ => fs.chmod(join(target, actualBin), 0o755))
       .then(_ => mkdirp(join(modules, '.bin')))
       .then(_ => debug('linking %s -> %s',
-        join(finalTarget, '_', actualBin),
+        join(finalTarget, actualBin),
         join(modules, '.bin', bin)))
       .then(_ => relSymlink(
-        join(finalTarget, '_', actualBin),
+        join(finalTarget, actualBin),
         join(modules, '.bin', bin)))
   })
 }

--- a/lib/install/link_bins.js
+++ b/lib/install/link_bins.js
@@ -20,7 +20,7 @@ var debug = require('debug')('pnpm:link_bins')
  */
 
 module.exports = function linkBins (modules, target, finalTarget) {
-  var pkg = tryRequire(join(target, 'package.json'))
+  var pkg = tryRequire(join(target, '_', 'package.json'))
   if (!pkg || !pkg.bin) return
 
   var bins = binify(pkg)
@@ -29,13 +29,13 @@ module.exports = function linkBins (modules, target, finalTarget) {
     var actualBin = bins[bin]
 
     return Promise.resolve()
-      .then(_ => fs.chmod(join(target, actualBin), 0o755))
+      .then(_ => fs.chmod(join(target, '_', actualBin), 0o755))
       .then(_ => mkdirp(join(modules, '.bin')))
       .then(_ => debug('linking %s -> %s',
-        join(finalTarget, actualBin),
+        join(finalTarget, '_', actualBin),
         join(modules, '.bin', bin)))
       .then(_ => relSymlink(
-        join(finalTarget, actualBin),
+        join(finalTarget, '_', actualBin),
         join(modules, '.bin', bin)))
   })
 }

--- a/lib/install/link_bins.js
+++ b/lib/install/link_bins.js
@@ -3,6 +3,7 @@ var relSymlink = require('../rel_symlink')
 var fs = require('mz/fs')
 var mkdirp = require('../mkdirp')
 var debug = require('debug')('pnpm:link_bins')
+var requireJson = require('../fs/require_json')
 
 /*
  * Links executables into `node_modules/.bin`.
@@ -45,7 +46,7 @@ module.exports = function linkBins (modules, target, finalTarget) {
  */
 
 function tryRequire (path) {
-  try { return require(path) } catch (e) { }
+  try { return requireJson(path) } catch (e) { }
 }
 
 /*

--- a/lib/install/link_bundled_deps.js
+++ b/lib/install/link_bundled_deps.js
@@ -4,7 +4,7 @@ var join = require('path').join
 var linkBins = require('./link_bins')
 
 module.exports = function linkBundledDeps (root) {
-  var nodeModules = join(root, '_', 'node_modules')
+  var nodeModules = join(root, 'node_modules')
 
   return isDir(nodeModules, _ =>
     Promise.all(fs.readdir(nodeModules).map(mod =>

--- a/lib/install/link_bundled_deps.js
+++ b/lib/install/link_bundled_deps.js
@@ -4,7 +4,7 @@ var join = require('path').join
 var linkBins = require('./link_bins')
 
 module.exports = function linkBundledDeps (root) {
-  var nodeModules = join(root, 'node_modules')
+  var nodeModules = join(root, '_', 'node_modules')
 
   return isDir(nodeModules, _ =>
     Promise.all(fs.readdir(nodeModules).map(mod =>

--- a/lib/install/post_install.js
+++ b/lib/install/post_install.js
@@ -7,7 +7,8 @@ var delimiter = require('path').delimiter
 var byline = require('byline')
 var fs = require('mz/fs')
 
-module.exports = function postInstall (root, pkg, log) {
+module.exports = function postInstall (root_, pkg, log) {
+  var root = join(root_, '_')
   debug('postinstall', pkg.name + '@' + pkg.version)
   var scripts = pkg && pkg.scripts || {}
   return Promise.resolve()

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-config-standard": "4.4.0",
     "eslint-plugin-standard": "1.3.1",
     "nixt": "0.5.0",
+    "npm": "3.6.0",
     "sepia": "2.0.1",
     "tap-spec": "4.1.1",
     "tape": "4.4.0",

--- a/test/index.js
+++ b/test/index.js
@@ -147,3 +147,19 @@ test('tarballs (is-array-1.0.1.tgz)', function (t) {
   }, t.end)
 })
 
+test('shrinkwrap compatibility', function (t) {
+  prepare()
+  fs.writeFileSync('package.json',
+    JSON.stringify({ dependencies: { rimraf: '*' } }),
+    'utf-8')
+
+  install({ input: ['rimraf@2.5.1'], flags: { quiet: true } })
+  .then(function () {
+    var npm = JSON.stringify(require.resolve('npm/bin/npm-cli.js'))
+    require('child_process').execSync('node ' + npm + ' shrinkwrap')
+    var wrap = JSON.parse(fs.readFileSync('npm-shrinkwrap.json', 'utf-8'))
+    t.ok(wrap.dependencies.rimraf.version === '2.5.1',
+      'npm shrinkwrap is successful')
+    t.end()
+  }, t.end)
+})


### PR DESCRIPTION
When you do `npm ls` in a pnpm-managed store, you get `extraneous` errors. This prevents you from shrinkwrapping.

This fixes that. Aww yiss.