### PR TITLE
npm3-style flatness

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-node_modules
-fixtures
-.tmp
-test
-*.md

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 > unreleased
 
 - [#41] - Support `--save`, `--save-dev` and `--save-exact`. ([@davej])
+- [#46] - Support modules being able to `require()` their peer dependencies (aka, emulate npm3-style flatness)
 
 [v0.13.0]: https://github.com/rstacruz/pnpm/compare/v0.12.1...v0.13.0
 
@@ -165,6 +166,7 @@
 [#36]: https://github.com/rstacruz/pnpm/issues/36
 [#38]: https://github.com/rstacruz/pnpm/issues/38
 [#41]: https://github.com/rstacruz/pnpm/issues/41
+[#46]: https://github.com/rstacruz/pnpm/issues/46
 [@indexzero]: https://github.com/indexzero
 [@rstacruz]: https://github.com/rstacruz
 [@davej]: https://github.com/davej

--- a/bin/pnpm-install
+++ b/bin/pnpm-install
@@ -4,107 +4,53 @@ if (~process.argv.indexOf('--debug')) {
   process.argv.push('--quiet')
 }
 
-var dirname = require('path').dirname
-var join = require('path').join
-var readPkgUp = require('read-pkg-up')
-var assign = require('object-assign')
-var npa = require('npm-package-arg')
+var installCmd = require('../lib/cmd/install')
 
-var logger = require('../lib/logger')
-var installMultiple = require('../lib/install_multiple')
-var config = require('../lib/config')
-var save = require('../lib/save')
-
-const cli = require('meow')([
-  'Usage:',
-  '  $ pnpm install',
-  '  $ pnpm install <name>',
-  '',
-  'Options:',
-  '  -S, --save            save into package.json under dependencies',
-  '  -D, --save-dev        save into package.json under devDependencies',
-  '  -E, --save-exact      save exact spec',
-  '',
-  '      --dry-run         simulate',
-  '  -g, --global          install globally',
-  '',
-  '      --production      don\'t install devDependencies',
-  '      --quiet           don\'t print progress'
-].join('\n'), {
-  boolean: [
-    'save-dev', 'save', 'save-exact', 'dry-run', 'global', 'quiet', 'debug'
-  ],
-  alias: {
-    'no-progress': 'quiet',
-    D: 'save-dev',
-    S: 'save',
-    E: 'save-exact',
-    g: 'global'
-  }
-})
-
-if (cli.flags.debug) {
-  cli.flags.quiet = true
-}
-
-['dryRun', 'global'].forEach(flag => {
-  if (cli.flags[flag]) {
-    console.error("Error: '" + flag + "' is not supported yet, sorry!")
-    process.exit(1)
-  }
-})
-
-/*
- * Perform
- */
-
-function run (cli) {
-  var ctx = {}
-  var pkg
-  var packagesToInstall
-  var installType
-
-  return readPkgUp()
-    .then(pkg_ => { pkg = pkg_ })
-    .then(_ => updateContext(pkg.path))
-    .then(_ => install())
-
-  function install () {
-    installType = cli.input && cli.input.length ? 'named' : 'general'
-
-    if (installType === 'named') {
-      packagesToInstall = cli.input
-    } else {
-      packagesToInstall = assign({},
-        pkg.pkg.dependencies || {},
-        pkg.pkg.devDependencies || {})
+function run (argv) {
+  const cli = require('meow')({
+    argv: argv,
+    help: [
+      'Usage:',
+      '  $ pnpm install',
+      '  $ pnpm install <name>',
+      '',
+      'Options:',
+      '  -S, --save            save into package.json under dependencies',
+      '  -D, --save-dev        save into package.json under devDependencies',
+      '  -E, --save-exact      save exact spec',
+      '',
+      '      --dry-run         simulate',
+      '  -g, --global          install globally',
+      '',
+      '      --production      don\'t install devDependencies',
+      '      --quiet           don\'t print progress'
+    ].join('\n')
+  }, {
+    boolean: [
+      'save-dev', 'save', 'save-exact', 'dry-run', 'global', 'quiet', 'debug'
+    ],
+    alias: {
+      'no-progress': 'quiet',
+      D: 'save-dev',
+      S: 'save',
+      E: 'save-exact',
+      g: 'global'
     }
+  })
 
-    return installMultiple(ctx,
-      packagesToInstall,
-      join(ctx.root, 'node_modules'),
-      cli.flags)
-      .then(savePkgs)
+  if (cli.flags.debug) {
+    cli.flags.quiet = true
   }
 
-  function updateContext (packageJson) {
-    var root = packageJson ? dirname(packageJson) : process.cwd()
-    ctx.root = root
-    ctx.store = join(root, config.pnpm_store_path)
-    if (!cli.flags.quiet) ctx.log = logger()
-    else ctx.log = function () { return function () {} }
-  }
-
-  function savePkgs (packages) {
-    var saveType = cli.flags.save ? 'dependencies' : cli.flags.saveDev ? 'devDependencies' : null
-    if (saveType && installType === 'named') {
-      var inputNames = cli.input.map(pkgName => npa(pkgName).name)
-      var savedPackages = packages.filter(pkg => inputNames.indexOf(pkg.name) > -1)
-      return save(pkg, savedPackages, saveType, cli.flags.saveExact)
+  ['dryRun', 'global'].forEach(flag => {
+    if (cli.flags[flag]) {
+      console.error("Error: '" + flag + "' is not supported yet, sorry!")
+      process.exit(1)
     }
-  }
+  })
+
+  return installCmd(cli).catch(require('../lib/err'))
 }
 
 module.exports = run
-
-if (!module.parent) run(cli).catch(require('../lib/err'))
+if (!module.parent) run(process.argv.slice(2))

--- a/lib/cmd/install.js
+++ b/lib/cmd/install.js
@@ -1,0 +1,63 @@
+var readPkgUp = require('read-pkg-up')
+var dirname = require('path').dirname
+var join = require('path').join
+var assign = require('object-assign')
+var npa = require('npm-package-arg')
+
+var logger = require('../logger')
+var installMultiple = require('../install_multiple')
+var config = require('../config')
+var save = require('../save')
+
+/*
+ * Perform
+ */
+
+function run (cli) {
+  var ctx = {}
+  var pkg
+  var packagesToInstall
+  var installType
+
+  return readPkgUp()
+    .then(pkg_ => { pkg = pkg_ })
+    .then(_ => updateContext(pkg.path))
+    .then(_ => install())
+
+  function install () {
+    installType = cli.input && cli.input.length ? 'named' : 'general'
+
+    if (installType === 'named') {
+      packagesToInstall = cli.input
+    } else {
+      packagesToInstall = assign({},
+        pkg.pkg.dependencies || {},
+        pkg.pkg.devDependencies || {})
+    }
+
+    return installMultiple(ctx,
+      packagesToInstall,
+      join(ctx.root, 'node_modules'),
+      cli.flags)
+      .then(savePkgs)
+  }
+
+  function updateContext (packageJson) {
+    var root = packageJson ? dirname(packageJson) : process.cwd()
+    ctx.root = root
+    ctx.store = join(root, config.pnpm_store_path)
+    if (!cli.flags.quiet) ctx.log = logger()
+    else ctx.log = function () { return function () {} }
+  }
+
+  function savePkgs (packages) {
+    var saveType = cli.flags.save ? 'dependencies' : cli.flags.saveDev ? 'devDependencies' : null
+    if (saveType && installType === 'named') {
+      var inputNames = cli.input.map(pkgName => npa(pkgName).name)
+      var savedPackages = packages.filter(pkg => inputNames.indexOf(pkg.name) > -1)
+      return save(pkg, savedPackages, saveType, cli.flags.saveExact)
+    }
+  }
+}
+
+module.exports = run

--- a/lib/cmd/install.js
+++ b/lib/cmd/install.js
@@ -8,6 +8,7 @@ var logger = require('../logger')
 var installMultiple = require('../install_multiple')
 var config = require('../config')
 var save = require('../save')
+var linkPeers = require('../install/link_peers')
 
 /*
  * Perform
@@ -20,9 +21,10 @@ function run (cli) {
   var installType
 
   return readPkgUp()
-    .then(pkg_ => { pkg = pkg_ })
+    .then(_ => { pkg = _ })
     .then(_ => updateContext(pkg.path))
     .then(_ => install())
+    .then(_ => linkPeers(pkg, ctx.store, ctx.installs))
 
   function install () {
     installType = cli.input && cli.input.length ? 'named' : 'general'

--- a/lib/fs/unsymlink.js
+++ b/lib/fs/unsymlink.js
@@ -1,0 +1,16 @@
+var fs = require('mz/fs')
+
+/*
+ * Removes a symlink
+ */
+
+module.exports = function unsymlink (path) {
+  return fs.lstat(path)
+  .then(stat => {
+    if (stat.isSymbolicLink()) return fs.unlink(path)
+    throw new Error('Can\'t unlink ' + path)
+  })
+  .catch(err => {
+    if (err.code !== 'ENOENT') throw err
+  })
+}

--- a/lib/install.js
+++ b/lib/install.js
@@ -85,19 +85,17 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   var log = ctx.log(pkg.spec) // function
 
   // it might be a bundleDependency, in which case, don't bother
-  return isBundled(pkg.spec.name, modules, {
-    then: _ =>
-      saveCachedResolution()
-        .then(data => log('package.json', data)),
-    else: _ =>
-      resolve(pkg.spec)
+  return isBundled(pkg.spec.name, modules)
+    .then(_ => _
+      ? saveCachedResolution()
+        .then(data => log('package.json', data))
+      : resolve(pkg.spec)
         .then(saveResolution)
         .then(_ => log('resolved', pkg))
         .then(_ => buildToStoreCached(ctx, paths, pkg, log))
         .then(_ => mkdirp(paths.modules))
         .then(_ => symlinkToModules(join(paths.target, '_'), paths.modules))
-        .then(_ => log('package.json', requireJson(join(paths.target, '_', 'package.json'))))
-  })
+        .then(_ => log('package.json', requireJson(join(paths.target, '_', 'package.json')))))
     // done
     .then(_ => {
       if (!ctx.installs) ctx.installs = {}
@@ -149,15 +147,15 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
  * 'node_modules/lodash' already exists.
  */
 
-function isBundled (name, modules, run) {
-  if (!name) return run.else && run.else()
+function isBundled (name, modules) {
+  if (!name) return Promise.resolve(false)
 
   return Promise.resolve()
     .then(_ => fs.statSync(join(modules, name, 'package.json')))
-    .then(_ => run.then && run.then())
+    .then(_ => true)
     .catch(err => {
       if (err.code !== 'ENOENT') throw err
-      return run.else && run.else()
+      return false
     })
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -120,15 +120,24 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   }
 
   function saveCachedResolution () {
-    return fs.readlink(join(modules, pkg.spec.name))
-      .then(fullpath => {
-        var data = requireJson(join(fullpath, 'package.json'))
-        pkg.name = data.name
-        pkg.fullname = basename(fullpath)
-        pkg.version = data.version
-        pkg.data = data
-        paths.target = fullpath
+    var target = join(modules, pkg.spec.name)
+    return fs.lstat(target)
+      .then(stat => {
+        if (stat.isSymbolicLink()) {
+          return fs.readlink(target).then(save)
+        } else {
+          return save(target)
+        }
       })
+
+    function save (fullpath) {
+      var data = requireJson(join(fullpath, 'package.json'))
+      pkg.name = data.name
+      pkg.fullname = basename(fullpath)
+      pkg.version = data.version
+      pkg.data = data
+      paths.target = fullpath
+    }
   }
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -100,9 +100,11 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   })
     // done
     .then(_ => {
-      log('done')
-      return pkg
+      if (!ctx.installs) ctx.installs = {}
+      ctx.installs[pkg.fullname] = pkg
     })
+    .then(_ => log('done'))
+    .then(_ => pkg)
     .catch(err => {
       log('error', err)
       throw err

--- a/lib/install.js
+++ b/lib/install.js
@@ -122,7 +122,8 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
     return fs.lstat(target)
       .then(stat => {
         if (stat.isSymbolicLink()) {
-          return fs.readlink(target).then(save)
+          return fs.readlink(target)
+            .then(path => save(abspath(path, target)))
         } else {
           return save(target)
         }

--- a/lib/install.js
+++ b/lib/install.js
@@ -3,6 +3,7 @@ var debug = require('debug')('pnpm:install')
 var npa = require('npm-package-arg')
 var join = require('path').join
 var dirname = require('path').dirname
+var basename = require('path').basename
 var abspath = require('path').resolve
 var mkdirp = require('./mkdirp')
 var fetch = require('./fetch')
@@ -85,10 +86,9 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
 
   // it might be a bundleDependency, in which case, don't bother
   return isBundled(pkg.spec.name, modules, {
-    then: _ => {
-      paths.target = join(modules, pkg.spec.name)
-      log('package.json', requireJson(join(paths.target, 'package.json')))
-    },
+    then: _ =>
+      saveCachedResolution()
+        .then(data => log('package.json', data)),
     else: _ =>
       resolve(pkg.spec)
         .then(saveResolution)
@@ -117,6 +117,18 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
     pkg.version = res.version
     pkg.dist = res.dist
     paths.target = join(ctx.store, res.fullname)
+  }
+
+  function saveCachedResolution () {
+    return fs.readlink(join(modules, pkg.spec.name))
+      .then(fullpath => {
+        var data = requireJson(join(fullpath, 'package.json'))
+        pkg.name = data.name
+        pkg.fullname = basename(fullpath)
+        pkg.version = data.version
+        pkg.data = data
+        paths.target = fullpath
+      })
   }
 }
 

--- a/lib/install/link_peers.js
+++ b/lib/install/link_peers.js
@@ -27,13 +27,15 @@ module.exports = function linkPeers (pkg, store, installs) {
 
   var modules = join(store, 'node_modules')
   return mkdirp(modules)
-    .then(_ => Promise.all(Object.keys(roots).map(name =>
-      unsymlink(join(modules, roots[name].name))
-    )))
+    .then(_ => Promise.all(Object.keys(roots).map(name => {
+      return unsymlink(join(modules, roots[name].name))
+    })))
     .then(_ => Promise.all(Object.keys(peers).map(name =>
-      relSymlink(
-        join('..', peers[name].fullname),
-        join(modules, peers[name].name))
+      unsymlink(join(modules, peers[name].name))
+      .then(_ =>
+        relSymlink(
+          join(store, peers[name].fullname, '_'),
+          join(modules, peers[name].name)))
     )))
 }
 

--- a/lib/install/link_peers.js
+++ b/lib/install/link_peers.js
@@ -1,0 +1,39 @@
+var Promise = require('../promise')
+var mkdirp = require('../mkdirp')
+var unsymlink = require('../fs/unsymlink')
+var relSymlink = require('../rel_symlink')
+var join = require('path').join
+var semver = require('semver')
+
+/*
+ * Links into `.store/node_modules`
+ */
+
+module.exports = function linkPeers (pkg, store, installs) {
+  var peers = {}
+  var roots = {}
+
+  Object.keys(installs).forEach(name => {
+    var pkgData = installs[name]
+    var realname = pkgData.name
+
+    if (pkgData.keypath.length === 0) {
+      roots[realname] = pkgData
+    } else if (!peers[realname] ||
+      semver.gt(pkgData.version, peers[realname].version)) {
+      peers[realname] = pkgData
+    }
+  })
+
+  var modules = join(store, 'node_modules')
+  return mkdirp(modules)
+    .then(_ => Promise.all(Object.keys(roots).map(name =>
+      unsymlink(join(modules, roots[name].name))
+    )))
+    .then(_ => Promise.all(Object.keys(peers).map(name =>
+      relSymlink(
+        join('..', peers[name].fullname),
+        join(modules, peers[name].name))
+    )))
+}
+

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "bugs": {
     "url": "https://github.com/rstacruz/pnpm/issues"
   },
+  "files": [
+    "lib",
+    "bin"
+  ],
   "dependencies": {
     "bluebird": "3.1.5",
     "byline": "4.2.1",

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ var test = require('tape')
 var join = require('path').join
 var fs = require('fs')
 var prepare = require('./support/prepare')
-var install = require('../bin/pnpm-install')
+var install = require('../lib/cmd/install')
 require('./support/sepia')
 var stat
 


### PR DESCRIPTION
This emulates npm3's "flat" storage without actually being flat. This allows us to use peerDependencies. Work in progress; answers #42.

### How?

Given this dep tree:

- rimraf *
 - glob ^6.0.1
   - inflight ^1.0.4
   - inherits 2 

It'll create these:

```
node_modules/.store/rimraf@2.5.1/_
node_modules/.store/glob@6.0.4/_
node_modules/.store/inflight@1.0.4/_
node_modules/.store/inherits@2.0.1/_
node_modules/rimraf (symlink)
```

but also create these symlinks:

```
node_modules/.store/node_modules/rimraf
node_modules/.store/node_modules/glob
node_modules/.store/node_modules/inflight
node_modules/.store/node_modules/inherits
```

that way, `inflight` can `require('inherits')` and it'll work. this also does so without any polution in `node_modules`, which means `npm ls` and `npm shrinkwrap` will work. \o/