### PR TITLE
Detect number of parameters, exit if less then 2.

### DIFF
--- a/bin/pnpm
+++ b/bin/pnpm
@@ -1,4 +1,11 @@
 #!/usr/bin/env sh
+
+if [ "$#" -lt "1" ]; then
+  echo "You should pass at least 1 parameter to pnpm" 1>&2
+  pnpm-install --help
+  exit 1
+fi
+
 cmd=$1
 shift
 args=$*


### PR DESCRIPTION
Without this detection,

if a user gives no parameter, the error message will be:
> shift: can't shift that many

Tell the users to pass at least 1 parameter and then print `pnpm-install --help` to improve the UX.