### PR TITLE
Enable container-based infrastructure on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ node_js:
 #   directories:
 #   - node_modules
 #   - fixtures
+sudo: false
 env:
   - CC=clang CXX=clang++ npm_config_clang=1


### PR DESCRIPTION
To make the build faster.

Reference:
https://docs.travis-ci.com/user/workers/container-based-infrastructure/