### PR TITLE
Be compatible with Node.js 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.10'
+- '0.12'
 - '4.2.6'
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: node_js
 node_js:
-- '4'
+- '0.10'
+- '4.2.6'
 cache:
   directories:
   - node_modules
 sudo: false
 script:
-- npm test
+- npm run test:babel
 - rm -rf .tmp
-- ./node_modules/.bin/docpress build
+- if [ "$(node -v)" = "v4.2.6" ]; then ./node_modules/.bin/docpress build; fi
 after_success:
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then ./node_modules/.bin/git-update-ghpages -e; fi
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.12'
+- '0.10'
 - '4.2.6'
 cache:
   directories:

--- a/bin/pnpm-install
+++ b/bin/pnpm-install
@@ -44,7 +44,7 @@ function run (argv) {
     cli.flags.quiet = true
   }
 
-  ['dryRun', 'global', 'production'].forEach(flag => {
+  ['dryRun', 'global', 'production'].forEach(function (flag) {
     if (cli.flags[flag]) {
       console.error("Error: '" + flag + "' is not supported yet, sorry!")
       process.exit(1)

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,3 +1,3 @@
-require('bluebird').config({ warnings: false })
-global.Promise = require('bluebird')
-module.exports = global.Promise
+var Promise = require('bluebird')
+Promise.config({ warnings: false })
+module.exports = Promise

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "url": "git+https://github.com/rstacruz/pnpm.git"
   },
   "scripts": {
-    "build": "if [ ! -d lib~ ]; then mv lib lib~; babel -D lib~ -d lib; fi",
+    "build": "if [ ! -d lib~ ]; then mv lib lib~; babel --retain-lines -D lib~ -d lib; fi",
     "test": "node test | tap-spec",
     "test:babel": "babel-node test | tap-spec",
     "prepublish": "if in-publish; then npm run build; fi",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   },
   "devDependencies": {
     "babel-cli": "6.4.5",
-    "babel-preset-es2015": "6.3.13",
+    "babel-plugin-transform-es2015-arrow-functions": "6.3.13",
+    "babel-plugin-transform-es2015-literals": "6.3.13",
     "docpress": "0.6.10",
     "eslint": "1.10.3",
     "eslint-config-standard": "4.4.0",
@@ -79,8 +80,9 @@
     "postpublish": "rm -rf lib; mv lib~ lib"
   },
   "babel": {
-    "presets": [
-      "es2015"
+    "plugins": [
+      "transform-es2015-arrow-functions",
+      "transform-es2015-literals"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "bin"
   ],
   "dependencies": {
+    "babel-cli": "6.4.5",
+    "babel-preset-es2015": "6.3.13",
     "bluebird": "3.2.1",
     "byline": "4.2.1",
     "chalk": "1.1.1",
     "commondir": "1.0.1",
     "debug": "2.2.0",
-    "got": "6.1.1",
+    "got": "5.4.1",
     "gunzip-maybe": "1.3.1",
     "meow": "3.7.0",
     "mkdirp": "0.5.1",
@@ -41,11 +43,13 @@
     "throat": "2.0.2"
   },
   "devDependencies": {
+    "babel-cli": "6.4.5",
     "docpress": "0.6.10",
     "eslint": "1.10.3",
     "eslint-config-standard": "4.4.0",
     "eslint-plugin-standard": "1.3.1",
     "git-update-ghpages": "1.3.0",
+    "in-publish": "2.0.0",
     "nixt": "0.5.0",
     "npm": "3.6.0",
     "sepia": "2.0.1",
@@ -69,7 +73,15 @@
     "url": "git+https://github.com/rstacruz/pnpm.git"
   },
   "scripts": {
-    "lol": "which node-gyp",
-    "test": "node test | tap-spec"
+    "build": "if [ ! -d lib~ ]; then mv lib lib~; babel -D lib~ -d lib; fi",
+    "test": "node test | tap-spec",
+    "test:babel": "babel-node test | tap-spec",
+    "prepublish": "if in-publish; then npm run build; fi",
+    "postpublish": "rm -rf lib; mv lib~ lib"
+  },
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "bin"
   ],
   "dependencies": {
-    "babel-cli": "6.4.5",
-    "babel-preset-es2015": "6.3.13",
     "bluebird": "3.2.1",
     "byline": "4.2.1",
     "chalk": "1.1.1",
@@ -44,6 +42,7 @@
   },
   "devDependencies": {
     "babel-cli": "6.4.5",
+    "babel-preset-es2015": "6.3.13",
     "docpress": "0.6.10",
     "eslint": "1.10.3",
     "eslint-config-standard": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "url": "git+https://github.com/rstacruz/pnpm.git"
   },
   "scripts": {
-    "build": "if [ ! -d lib~ ]; then mv lib lib~; babel --retain-lines -D lib~ -d lib; fi",
+    "build": "if [ ! -d lib~ ]; then mv lib lib~; babel --source-maps inline -D lib~ -d lib; fi",
     "test": "node test | tap-spec",
     "test:babel": "babel-node test | tap-spec",
     "prepublish": "if in-publish; then npm run build; fi",

--- a/test/index.js
+++ b/test/index.js
@@ -158,11 +158,13 @@ test('shrinkwrap compatibility', function (t) {
   install(['rimraf@2.5.1'], { quiet: true })
   .then(function () {
     var npm = JSON.stringify(require.resolve('npm/bin/npm-cli.js'))
-    require('child_process').execSync('node ' + npm + ' shrinkwrap')
-    var wrap = JSON.parse(fs.readFileSync('npm-shrinkwrap.json', 'utf-8'))
-    t.ok(wrap.dependencies.rimraf.version === '2.5.1',
-      'npm shrinkwrap is successful')
-    t.end()
+    require('child_process').exec('node ' + npm + ' shrinkwrap', function (err) {
+      if (err) return t.end(err)
+      var wrap = JSON.parse(fs.readFileSync('npm-shrinkwrap.json', 'utf-8'))
+      t.ok(wrap.dependencies.rimraf.version === '2.5.1',
+        'npm shrinkwrap is successful')
+      t.end()
+    })
   }, t.end)
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -235,7 +235,7 @@ test('flattening symlinks (minimatch + balanced-match)', function (t) {
   prepare()
   install(['minimatch@3.0.0'], { quiet: true })
   .then(function () {
-    return install({ ['balanced-match@^0.3.0'], { quiet: true })
+    return install(['balanced-match@^0.3.0'], { quiet: true })
   })
   .then(function () {
     _ = exists(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))

--- a/test/index.js
+++ b/test/index.js
@@ -234,7 +234,9 @@ test('flattening symlinks (minimatch@3.0.0)', function (t) {
 test('flattening symlinks (minimatch + balanced-match)', function (t) {
   prepare()
   install(['minimatch@3.0.0'], { quiet: true })
-  .then(_ => install(['balanced-match@^0.3.0'], { quiet: true }))
+  .then(function () {
+    return install({ ['balanced-match@^0.3.0'], { quiet: true })
+  })
   .then(function () {
     _ = exists(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))
     t.ok(!_, 'balanced-match is removed from store node_modules')

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ test('small with dependencies (rimraf)', function (t) {
     t.ok(stat.isSymbolicLink(), '.bin/rimraf symlink is available')
 
     stat = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf', 'bin.js'))
-    t.equal(stat.mode, 0o100755, 'rimraf is executable')
+    t.equal(stat.mode, parseInt('100755', 8), 'rimraf is executable')
     t.ok(stat.isFile(), '.bin/rimraf refers to a file')
 
     t.end()


### PR DESCRIPTION
This will transpile `lib/` down to Node 0.10 compatible syntax before publishing.

This supports all the way down to node 0.10, but that version comes with npm1.4. pnpm will work just fine with it, but to get support for `shrinkwrap` they'd need to upgrade to `npm@2`.