### PR TITLE
Always provide an argument for shift

### DIFF
--- a/bin/pnpm
+++ b/bin/pnpm
@@ -7,12 +7,12 @@ if [ "$#" -lt "1" ]; then
 fi
 
 cmd=$1
-shift
+shift $(( $# > 0 ? 1 : 0 ))
 args=$*
 
 case $cmd in
   h | help | -h | --help)
-    shift
+    shift $(( $# > 0 ? 1 : 0 ))
     cmd=$args
     args=--help
     ;;


### PR DESCRIPTION
I got hit by [this](http://superuser.com/questions/897148/shell-cant-shift-that-many-error).

```bash
❯ pnpm --help
/usr/local/bin/pnpm: 15: shift: can't shift that many
```

By always providing an argument for `shift` it should work for all shells :smile: :+1: 