### PR TITLE
Use npm's resolution algorithm

### DIFF
--- a/lib/resolve/npm.js
+++ b/lib/resolve/npm.js
@@ -28,16 +28,14 @@ module.exports = function resolveNpm (pkg, log) {
       return res.promise
     }))
     .then(res => JSON.parse(res.body))
-    .catch(err => err.statusCode === 404
-      ? getAllVersionsAndMatchOnClient(pkg)
-      : errify(err, pkg)
-    )
+    .then(res => pickVersionFromRegistryDocument(res, pkg))
     .then(res => ({
       name: res.name,
       fullname: '' + res.name.replace('/', '!') + '@' + res.version,
       version: res.version, // used for displaying
       dist: res.dist
     }))
+    .catch(err => errify(err, pkg))
 }
 
 function errify (err, pkg) {
@@ -47,32 +45,18 @@ function errify (err, pkg) {
   throw err
 }
 
-function getAllVersionsAndMatchOnClient (pkg) {
-  return Promise.resolve()
-    .then(_ => url.resolve(registryUrl(pkg.scope), pkg.name))
-    .then(url => got.get(url).then(res => res.promise))
-    .then(res => JSON.parse(res.body))
-    .then(res => pickVersionFromRegistryDocument(res, pkg))
-    .catch(err => errify(err, pkg))
-}
-
 function pickVersionFromRegistryDocument (pkg, dep) {
   var versions = Object.keys(pkg.versions)
-  if (dep.tag === 'tag' && dep.spec === 'latest') {
-    var sortedVersions = versions.sort(semver.rcompare)
-    return pkg(sortedVersions[0])
-  }
 
-  if (dep.type === 'tag' && dep.spec !== 'latest') {
+  if (dep.type === 'tag') {
     var tagVersion = pkg['dist-tags'][dep.spec]
     if (pkg.versions[tagVersion]) {
       return pkg.versions[tagVersion]
     }
   } else {
-    var spec = scopeWorkarounds(dep)
-    var maxSatisfyingVersion = semver.maxSatisfying(versions, spec)
-    if (maxSatisfyingVersion) {
-      return pkg.versions[maxSatisfyingVersion]
+    var maxVersion = semver.maxSatisfying(versions, dep.spec)
+    if (maxVersion) {
+      return pkg.versions[maxVersion]
     }
   }
 
@@ -92,8 +76,7 @@ function pickVersionFromRegistryDocument (pkg, dep) {
  */
 
 function toUri (pkg) {
-  // TODO: handle scoped packages
-  var name, uri
+  var name
 
   if (pkg.name.substr(0, 1) === '@') {
     name = '@' + enc(pkg.name.substr(1))
@@ -101,13 +84,7 @@ function toUri (pkg) {
     name = enc(pkg.name)
   }
 
-  if (pkg.name.substr(0, 1) === '@') {
-    uri = join(name, scopeWorkarounds(pkg))
-  } else {
-    uri = join(name, pkg.spec)
-  }
-
-  return url.resolve(registryUrl(pkg.scope), uri)
+  return url.resolve(registryUrl(pkg.scope), name)
 }
 
 /*

--- a/lib/resolve/npm.js
+++ b/lib/resolve/npm.js
@@ -1,4 +1,3 @@
-var join = require('path').join
 var url = require('url')
 var enc = global.encodeURIComponent
 var got = require('../got')
@@ -85,28 +84,4 @@ function toUri (pkg) {
   }
 
   return url.resolve(registryUrl(pkg.scope), name)
-}
-
-/*
- * The npm registry doesn't support resolutions of dist tags of scoped
- * packages, or exact versions... only ranges. This means you can't do `pnpm
- * install @rstacruz/tap-spec` or `pnpm install @rstacruz/tap-spec@latest`.
- *
- * As a workaround, we'll use `*` for `latest`. And for exact versions,
- * we'll convert them to a range (`=2.0.0`).
- *
- * OK   - https://registry.npmjs.org/@rstacruz%2Ftap-spec/*
- * Nope - https://registry.npmjs.org/@rstacruz%2Ftap-spec/latest
- */
-
-function scopeWorkarounds (pkg) {
-  if (pkg.type === 'tag' && pkg.spec === 'latest') {
-    return '*'
-  } else if (pkg.type === 'version') {
-    return '=' + pkg.spec
-  } else if (pkg.type === 'range') {
-    return pkg.spec
-  } else {
-    throw new Error('Unsupported for now: ' + pkg.raw)
-  }
 }


### PR DESCRIPTION
@misterbyrne, I've made your module resolution code the default method of finding packages. This is because the one we're using by default, `registry.npmjs.org/lodash/4.0.0`, is actually an undocumented endpoint (and hence not implemented by gemfury et al).

This instead uses `registry.npmjs.org/lodash`.

This has the following benefits:

- no more workarounds for scoped packages
- support for dist-tags for scoped packages
- faster gemfury downloads
- only need to fetch one json per package (eg, installing both lodash@2 and lodash@3 will perform 1 resolution, not one)
- faster dependency resolution for large packages because of the above (slightly?)

expect a possible slight performance dip for smaller packages, but not by much.