### PR TITLE
Allow installing new versions (#51)

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -1,4 +1,5 @@
 var Promise = require('./promise')
+var semver = require('semver')
 var debug = require('debug')('pnpm:install')
 var npa = require('npm-package-arg')
 var join = require('path').join
@@ -85,7 +86,7 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   var log = ctx.log(pkg.spec) // function
 
   // it might be a bundleDependency, in which case, don't bother
-  return isBundled(pkg.spec.name, modules)
+  return isBundled(pkg.spec, modules)
     .then(_ => _
       ? saveCachedResolution()
         .then(data => log('package.json', data))
@@ -148,16 +149,26 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
  * 'node_modules/lodash' already exists.
  */
 
-function isBundled (name, modules) {
+function isBundled (spec, modules) {
+  var name = spec && spec.name
   if (!name) return Promise.resolve(false)
 
+  var packageJsonPath = join(modules, name, 'package.json')
+
   return Promise.resolve()
-    .then(_ => fs.statSync(join(modules, name, 'package.json')))
-    .then(_ => true)
+    .then(_ => fs.readFile(packageJsonPath))
+    .then(_ => JSON.parse(_))
+    .then(_ => verify(spec, _))
     .catch(err => {
       if (err.code !== 'ENOENT') throw err
       return false
     })
+
+  function verify (spec, packageJson) {
+    return packageJson.name === spec.name &&
+      ((spec.type !== 'range' && spec.type !== 'version') ||
+      semver.satisfies(packageJson.version, spec.spec))
+  }
 }
 
 /*

--- a/test/index.js
+++ b/test/index.js
@@ -92,6 +92,17 @@ test('idempotency (rimraf)', function (t) {
   }, t.end)
 })
 
+test.only('overwriting (lodash@3.10.1 and @4.0.0)', function (t) {
+  prepare()
+  install(['lodash@3.10.1'], { quiet: true })
+  .then(function () { return install([ 'lodash@4.0.0' ], { quiet: true }) })
+  .then(function () {
+    _ = require(join(process.cwd(), 'node_modules', 'lodash', 'package.json'))
+    t.ok(_.version === '4.0.0', 'lodash is 4.0.0')
+    t.end()
+  }, t.end)
+})
+
 test('big with dependencies and circular deps (babel-preset-2015)', function (t) {
   prepare()
   install(['babel-preset-es2015@6.3.13'], { quiet: true })


### PR DESCRIPTION
#51. This allows you to do:

```
npm install lodash@3
npm install lodash@4
```

and it'll overwrite `lodash` with version 4.