### PR TITLE
Removes .only so other test cases won't be ignored

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -92,7 +92,7 @@ test('idempotency (rimraf)', function (t) {
   }, t.end)
 })
 
-test.only('overwriting (lodash@3.10.1 and @4.0.0)', function (t) {
+test('overwriting (lodash@3.10.1 and @4.0.0)', function (t) {
   prepare()
   install(['lodash@3.10.1'], { quiet: true })
   .then(function () { return install([ 'lodash@4.0.0' ], { quiet: true }) })


### PR DESCRIPTION
This is related to https://github.com/rstacruz/pnpm/pull/81 changes. I think you're taking advantage of `.only` for isolation of tests, but forgot to remove after working with the PR. :angel: 