### PR TITLE
remove production check in bin/pnpm-install

### DIFF
--- a/bin/pnpm-install
+++ b/bin/pnpm-install
@@ -44,7 +44,7 @@ function run (argv) {
     cli.flags.quiet = true
   }
 
-  ['dryRun', 'global', 'production'].forEach(function (flag) {
+  ['dryRun', 'global'].forEach(function (flag) {
     if (cli.flags[flag]) {
       console.error("Error: '" + flag + "' is not supported yet, sorry!")
       process.exit(1)


### PR DESCRIPTION
Suppoer for --production was added in https://github.com/rstacruz/pnpm/pull/68 - but the check against production in bin/pnpm-install was still there prohibiting --production from working.