### PR TITLE
Feature: sorted deps

### DIFF
--- a/lib/save.js
+++ b/lib/save.js
@@ -1,5 +1,6 @@
 var writeFile = require('mz/fs').writeFile
 var requireJson = require('./fs/require_json')
+var sortedObject = require('sorted-object')
 
 module.exports = function save (pkg, installedPackages, saveType, useExactVersion) {
   var packageJson = requireJson(pkg.path)
@@ -8,6 +9,7 @@ module.exports = function save (pkg, installedPackages, saveType, useExactVersio
     var semverCharacter = useExactVersion ? '' : '^'
     packageJson[saveType][dependency.spec.name] = semverCharacter + dependency.version
   })
+  packageJson[saveType] = sortedObject(packageJson[saveType])
 
   return writeFile(pkg.path, JSON.stringify(packageJson, null, 2) + '\n', 'utf8')
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "registry-url": "3.0.3",
     "rimraf": "2.5.1",
     "semver": "5.1.0",
+    "sorted-object": "^1.0.0",
     "supports-color": "^3.1.2",
     "tar-fs": "1.9.0",
     "thenify": "3.1.1",

--- a/test/index.js
+++ b/test/index.js
@@ -209,9 +209,9 @@ test('saveDev scoped module to package.json (@rstacruz/tap-spec)', function (t) 
   }, t.end)
 })
 
-test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & rimraf@2.5.1)', function (t) {
+test.only('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & rimraf@2.5.1) (in sorted order)', function (t) {
   prepare()
-  install(['@rstacruz/tap-spec@latest', 'rimraf@2.5.1'], { quiet: true, save: true, saveExact: true })
+  install(['rimraf@2.5.1', '@rstacruz/tap-spec@latest'], { quiet: true, save: true, saveExact: true })
   .then(function () {
     var tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
     t.ok(typeof tapSpec === 'function', 'tapSpec() is available')
@@ -222,10 +222,11 @@ test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & 
     var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
     var dependencies = JSON.parse(pkgJson).dependencies
     var expectedDeps = {
-      rimraf: '2.5.1',
-      '@rstacruz/tap-spec': '4.1.1'
+      '@rstacruz/tap-spec': '4.1.1',
+      rimraf: '2.5.1'
     }
     t.deepEqual(dependencies, expectedDeps, 'tap-spec and rimraf have been added to dependencies')
+    t.deepEqual(Object.keys(dependencies), Object.keys(expectedDeps), 'tap-spec and rimraf have been added to dependencies in sorted order')
 
     t.end()
   }, t.end)

--- a/test/index.js
+++ b/test/index.js
@@ -209,7 +209,7 @@ test('saveDev scoped module to package.json (@rstacruz/tap-spec)', function (t) 
   }, t.end)
 })
 
-test.only('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & rimraf@2.5.1) (in sorted order)', function (t) {
+test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & rimraf@2.5.1) (in sorted order)', function (t) {
   prepare()
   install(['rimraf@2.5.1', '@rstacruz/tap-spec@latest'], { quiet: true, save: true, saveExact: true })
   .then(function () {


### PR DESCRIPTION
`npm` [installs things][demo] in [sorted manner][sorted], `pnpm` doesn't, so if you use `npm` after `pnpm`, you will get rewrited `package.json` and messy diff. This is a fix

[demo]: https://github.com/iamstarkov/npm-install-sorted-demo
[sorted]: https://github.com/npm/npm/blob/master/lib/utils/deep-sort-object.js#L2