### PR TITLE
Enable proxy tunneling

### DIFF
--- a/lib/got.js
+++ b/lib/got.js
@@ -4,20 +4,11 @@ var assign = require('object-assign')
 var throat = require('throat')
 var got = require('got')
 var config = require('./config')
-var HttpAgent = require('http').Agent
-var HttpsAgent = require('https').Agent
+var caw = require('caw')
 
 var cache = {}
 
 var throater = throat(+config.concurrency)
-var httpKeepaliveAgent = new HttpAgent({
-  keepAlive: true,
-  keepAliveMsecs: 30000
-})
-var httpsKeepaliveAgent = new HttpsAgent({
-  keepAlive: true,
-  keepAliveMsecs: 30000
-})
 
 /*
  * waits in line
@@ -67,11 +58,7 @@ function waiter (stream) {
 
 function extend (url, options) {
   if (!options) options = {}
-  if (url.indexOf('https://') === 0) {
-    options.agent = httpsKeepaliveAgent
-  } else {
-    options.agent = httpKeepaliveAgent
-  }
+  options.agent = caw()
   return assign({}, options, {
     headers: assign({}, options.headers || {}, {
       'user-agent': 'https://github.com/rstacruz/pnpm'

--- a/lib/got.js
+++ b/lib/got.js
@@ -4,11 +4,21 @@ var assign = require('object-assign')
 var throat = require('throat')
 var got = require('got')
 var config = require('./config')
+var HttpAgent = require('http').Agent
+var HttpsAgent = require('https').Agent
 var caw = require('caw')
 
 var cache = {}
 
 var throater = throat(+config.concurrency)
+var httpKeepaliveAgent = new HttpAgent({
+  keepAlive: true,
+  keepAliveMsecs: 30000
+})
+var httpsKeepaliveAgent = new HttpsAgent({
+  keepAlive: true,
+  keepAliveMsecs: 30000
+})
 
 /*
  * waits in line
@@ -58,7 +68,11 @@ function waiter (stream) {
 
 function extend (url, options) {
   if (!options) options = {}
-  options.agent = caw()
+  if (url.indexOf('https://') === 0) {
+    options.agent = caw() || httpsKeepaliveAgent
+  } else {
+    options.agent = caw() || httpKeepaliveAgent
+  }
   return assign({}, options, {
     headers: assign({}, options.headers || {}, {
       'user-agent': 'https://github.com/rstacruz/pnpm'

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "bluebird": "3.3.1",
     "byline": "4.2.1",
+    "caw": "^1.2.0",
     "chalk": "1.1.1",
     "commondir": "1.0.1",
     "debug": "2.2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -4,312 +4,318 @@ var fs = require('fs')
 var prepare = require('./support/prepare')
 var basicPackageJson = require('./support/simple-package.json')
 var install = require('../index').install
-require('./support/sepia')
 
-var stat, _
-
-test('eslint', require('tape-eslint')())
-
-test('small with dependencies (rimraf)', function (t) {
-  prepare()
-  install(['rimraf@2.5.1'], { quiet: true })
-  .then(function () {
-    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
-    t.ok(typeof rimraf === 'function', 'rimraf() is available')
-
-    stat = fs.lstatSync(join(process.cwd(), 'node_modules', '.bin', 'rimraf'))
-    t.ok(stat.isSymbolicLink(), '.bin/rimraf symlink is available')
-
-    stat = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf', 'bin.js'))
-    t.equal(stat.mode, parseInt('100755', 8), 'rimraf is executable')
-    t.ok(stat.isFile(), '.bin/rimraf refers to a file')
-
-    t.end()
-  }, t.end)
-})
-
-test('no dependencies (lodash)', function (t) {
-  prepare()
-  install(['lodash@4.0.0'], { quiet: true })
-  .then(function () {
-    _ = require(join(process.cwd(), 'node_modules', 'lodash'))
-    t.ok(typeof _ === 'function', '_ is available')
-    t.ok(typeof _.clone === 'function', '_.clone is available')
-    t.end()
-  }, t.end)
-})
-
-test('scoped modules without version spec (@rstacruz/tap-spec)', function (t) {
-  prepare()
-  install(['@rstacruz/tap-spec'], { quiet: true })
-  .then(function () {
-    _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-    t.ok(typeof _ === 'function', 'tap-spec is available')
-    t.end()
-  }, t.end)
-})
-
-test('scoped modules with versions (@rstacruz/tap-spec@4.1.1)', function (t) {
-  prepare()
-  install(['@rstacruz/tap-spec@4.1.1'], { quiet: true })
-  .then(function () {
-    _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-    t.ok(typeof _ === 'function', 'tap-spec is available')
-    t.end()
-  }, t.end)
-})
-
-test('scoped modules (@rstacruz/tap-spec@*)', function (t) {
-  prepare()
-  install(['@rstacruz/tap-spec@*'], { quiet: true })
-  .then(function () {
-    _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-    t.ok(typeof _ === 'function', 'tap-spec is available')
-    t.end()
-  }, t.end)
-})
-
-test('multiple scoped modules (@rstacruz/...)', function (t) {
-  prepare()
-  install(['@rstacruz/tap-spec@*', '@rstacruz/travis-encrypt@*'], { quiet: true })
-  .then(function () {
-    _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-    t.ok(typeof _ === 'function', 'tap-spec is available')
-    _ = require(join(process.cwd(), 'node_modules', '@rstacruz/travis-encrypt'))
-    t.ok(typeof _ === 'function', 'travis-encrypt is available')
-    t.end()
-  }, t.end)
-})
-
-test('idempotency (rimraf)', function (t) {
-  prepare()
-  install(['rimraf@2.5.1'], { quiet: true })
-  .then(function () { return install([ 'rimraf@2.5.1' ], { quiet: true }) })
-  .then(function () {
-    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
-    t.ok(typeof rimraf === 'function', 'rimraf is available')
-    t.end()
-  }, t.end)
-})
-
-test('overwriting (lodash@3.10.1 and @4.0.0)', function (t) {
-  prepare()
-  install(['lodash@3.10.1'], { quiet: true })
-  .then(function () { return install([ 'lodash@4.0.0' ], { quiet: true }) })
-  .then(function () {
-    _ = require(join(process.cwd(), 'node_modules', 'lodash', 'package.json'))
-    t.ok(_.version === '4.0.0', 'lodash is 4.0.0')
-    t.end()
-  }, t.end)
-})
-
-test('big with dependencies and circular deps (babel-preset-2015)', function (t) {
-  prepare()
-  install(['babel-preset-es2015@6.3.13'], { quiet: true })
-  .then(function () {
-    var b = require(join(process.cwd(), 'node_modules', 'babel-preset-es2015'))
-    t.ok(typeof b === 'object', 'babel-preset-es2015 is available')
-    t.end()
-  }, t.end)
-})
-
-test('bundleDependencies (fsevents@1.0.6)', function (t) {
-  prepare()
-  install(['fsevents@1.0.6'], { quiet: true })
-  .then(function () {
-    stat = fs.lstatSync(
-      join(process.cwd(), 'node_modules', 'fsevents', 'node_modules', '.bin', 'mkdirp'))
-    t.ok(stat.isSymbolicLink(), '.bin/mkdirp is available')
-
-    stat = fs.statSync(
-      join(process.cwd(), 'node_modules', 'fsevents', 'node_modules', '.bin', 'mkdirp'))
-    t.ok(stat.isFile(), '.bin/mkdirp refers to a file')
-    t.end()
-  }, t.end)
-})
-
-test('compiled modules (ursa@0.9.1)', function (t) {
-  if (!process.env.CI) {
-    t.skip('only ran on CI')
-    return t.end()
+var npm = require('npm')
+npm.load({}, () => {
+  if (!npm.config.get('http-proxy') && !npm.config.get('https-proxy')) {
+    require('./support/sepia')
   }
 
-  prepare()
-  install(['ursa@0.9.1'], { quiet: false })
-  .then(function () {
-    var ursa = require(join(process.cwd(), 'node_modules', 'ursa'))
-    t.ok(typeof ursa === 'object', 'ursa() is available')
-    t.end()
-  }, t.end)
-})
+  var stat, _
 
-test('tarballs (is-array-1.0.1.tgz)', function (t) {
-  prepare()
-  install(['http://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz'], { quiet: true })
-  .then(function () {
-    var isArray = require(
-      join(process.cwd(), 'node_modules', 'is-array'))
+  test('eslint', require('tape-eslint')())
 
-    t.ok(isArray, 'isArray() is available')
+  test('small with dependencies (rimraf)', function (t) {
+    prepare()
+    install(['rimraf@2.5.1'], { quiet: true })
+    .then(function () {
+      var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+      t.ok(typeof rimraf === 'function', 'rimraf() is available')
 
-    stat = fs.statSync(
-      join(process.cwd(), 'node_modules', '.store',
-        'is-array-1.0.1#a83102a9c117983e6ff4d85311fb322231abe3d6'))
-    t.ok(stat.isDirectory(), 'stored in the proper location')
-    t.end()
-  }, t.end)
-})
+      stat = fs.lstatSync(join(process.cwd(), 'node_modules', '.bin', 'rimraf'))
+      t.ok(stat.isSymbolicLink(), '.bin/rimraf symlink is available')
 
-test('shrinkwrap compatibility', function (t) {
-  prepare()
-  fs.writeFileSync('package.json',
-    JSON.stringify({ dependencies: { rimraf: '*' } }),
-    'utf-8')
+      stat = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf', 'bin.js'))
+      t.equal(stat.mode, parseInt('100755', 8), 'rimraf is executable')
+      t.ok(stat.isFile(), '.bin/rimraf refers to a file')
 
-  install(['rimraf@2.5.1'], { quiet: true })
-  .then(function () {
-    var npm = JSON.stringify(require.resolve('npm/bin/npm-cli.js'))
-    require('child_process').exec('node ' + npm + ' shrinkwrap', function (err) {
-      if (err) return t.end(err)
-      var wrap = JSON.parse(fs.readFileSync('npm-shrinkwrap.json', 'utf-8'))
-      t.ok(wrap.dependencies.rimraf.version === '2.5.1',
-        'npm shrinkwrap is successful')
       t.end()
-    })
-  }, t.end)
-})
-
-test('save to package.json (rimraf@2.5.1)', function (t) {
-  prepare()
-  install(['rimraf@2.5.1'], { quiet: true, save: true })
-  .then(function () {
-    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
-    t.ok(typeof rimraf === 'function', 'rimraf() is available')
-
-    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-    var dependencies = JSON.parse(pkgJson).dependencies
-    t.deepEqual(dependencies, {rimraf: '^2.5.1'}, 'rimraf has been added to dependencies')
-
-    t.end()
-  }, t.end)
-})
-
-test('saveDev scoped module to package.json (@rstacruz/tap-spec)', function (t) {
-  prepare()
-  install(['@rstacruz/tap-spec'], { quiet: true, saveDev: true })
-  .then(function () {
-    var tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-    t.ok(typeof tapSpec === 'function', 'tapSpec() is available')
-
-    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-    var devDependencies = JSON.parse(pkgJson).devDependencies
-    t.deepEqual(devDependencies, { '@rstacruz/tap-spec': '^4.1.1' }, 'tap-spec has been added to devDependencies')
-
-    t.end()
-  }, t.end)
-})
-
-test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & rimraf@2.5.1) (in sorted order)', function (t) {
-  prepare()
-  install(['rimraf@2.5.1', '@rstacruz/tap-spec@latest'], { quiet: true, save: true, saveExact: true })
-  .then(function () {
-    var tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-    t.ok(typeof tapSpec === 'function', 'tapSpec() is available')
-
-    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
-    t.ok(typeof rimraf === 'function', 'rimraf() is available')
-
-    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-    var dependencies = JSON.parse(pkgJson).dependencies
-    var expectedDeps = {
-      '@rstacruz/tap-spec': '4.1.1',
-      rimraf: '2.5.1'
-    }
-    t.deepEqual(dependencies, expectedDeps, 'tap-spec and rimraf have been added to dependencies')
-    t.deepEqual(Object.keys(dependencies), Object.keys(expectedDeps), 'tap-spec and rimraf have been added to dependencies in sorted order')
-
-    t.end()
-  }, t.end)
-})
-
-test('flattening symlinks (minimatch@3.0.0)', function (t) {
-  prepare()
-  install(['minimatch@3.0.0'], { quiet: true })
-  .then(function () {
-    stat = fs.lstatSync(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))
-    t.ok(stat.isSymbolicLink(), 'balanced-match is linked into store node_modules')
-
-    _ = exists(join(process.cwd(), 'node_modules', 'balanced-match'))
-    t.ok(!_, 'balanced-match is not linked into main node_modules')
-    t.end()
-  }, t.end)
-})
-
-test('flattening symlinks (minimatch + balanced-match)', function (t) {
-  prepare()
-  install(['minimatch@3.0.0'], { quiet: true })
-  .then(function () {
-    return install(['balanced-match@^0.3.0'], { quiet: true })
+    }, t.end)
   })
-  .then(function () {
-    _ = exists(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))
-    t.ok(!_, 'balanced-match is removed from store node_modules')
 
-    _ = exists(join(process.cwd(), 'node_modules', 'balanced-match'))
-    t.ok(_, 'balanced-match now in main node_modules')
-    t.end()
-  }, t.end)
-})
-
-test('production install (with --production flag)', function (t) {
-  prepare()
-  fs.writeFileSync('package.json', JSON.stringify(basicPackageJson), 'utf-8')
-
-  return install([], { quiet: true, production: true })
+  test('no dependencies (lodash)', function (t) {
+    prepare()
+    install(['lodash@4.0.0'], { quiet: true })
     .then(function () {
-      var rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
+      _ = require(join(process.cwd(), 'node_modules', 'lodash'))
+      t.ok(typeof _ === 'function', '_ is available')
+      t.ok(typeof _.clone === 'function', '_.clone is available')
+      t.end()
+    }, t.end)
+  })
 
-      var tapStatErrCode
-      try {
-        fs.statSync(join(process.cwd(), 'node_modules', '@rstacruz'))
-      } catch (err) { tapStatErrCode = err.code }
+  test('scoped modules without version spec (@rstacruz/tap-spec)', function (t) {
+    prepare()
+    install(['@rstacruz/tap-spec'], { quiet: true })
+    .then(function () {
+      _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+      t.ok(typeof _ === 'function', 'tap-spec is available')
+      t.end()
+    }, t.end)
+  })
 
-      t.ok(rimrafDir.isSymbolicLink, 'rimraf exists')
-      t.is(tapStatErrCode, 'ENOENT', 'tap-spec does not exist')
+  test('scoped modules with versions (@rstacruz/tap-spec@4.1.1)', function (t) {
+    prepare()
+    install(['@rstacruz/tap-spec@4.1.1'], { quiet: true })
+    .then(function () {
+      _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+      t.ok(typeof _ === 'function', 'tap-spec is available')
+      t.end()
+    }, t.end)
+  })
+
+  test('scoped modules (@rstacruz/tap-spec@*)', function (t) {
+    prepare()
+    install(['@rstacruz/tap-spec@*'], { quiet: true })
+    .then(function () {
+      _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+      t.ok(typeof _ === 'function', 'tap-spec is available')
+      t.end()
+    }, t.end)
+  })
+
+  test('multiple scoped modules (@rstacruz/...)', function (t) {
+    prepare()
+    install(['@rstacruz/tap-spec@*', '@rstacruz/travis-encrypt@*'], { quiet: true })
+    .then(function () {
+      _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+      t.ok(typeof _ === 'function', 'tap-spec is available')
+      _ = require(join(process.cwd(), 'node_modules', '@rstacruz/travis-encrypt'))
+      t.ok(typeof _ === 'function', 'travis-encrypt is available')
+      t.end()
+    }, t.end)
+  })
+
+  test('idempotency (rimraf)', function (t) {
+    prepare()
+    install(['rimraf@2.5.1'], { quiet: true })
+    .then(function () { return install([ 'rimraf@2.5.1' ], { quiet: true }) })
+    .then(function () {
+      var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+      t.ok(typeof rimraf === 'function', 'rimraf is available')
+      t.end()
+    }, t.end)
+  })
+
+  test('overwriting (lodash@3.10.1 and @4.0.0)', function (t) {
+    prepare()
+    install(['lodash@3.10.1'], { quiet: true })
+    .then(function () { return install([ 'lodash@4.0.0' ], { quiet: true }) })
+    .then(function () {
+      _ = require(join(process.cwd(), 'node_modules', 'lodash', 'package.json'))
+      t.ok(_.version === '4.0.0', 'lodash is 4.0.0')
+      t.end()
+    }, t.end)
+  })
+
+  test('big with dependencies and circular deps (babel-preset-2015)', function (t) {
+    prepare()
+    install(['babel-preset-es2015@6.3.13'], { quiet: true })
+    .then(function () {
+      var b = require(join(process.cwd(), 'node_modules', 'babel-preset-es2015'))
+      t.ok(typeof b === 'object', 'babel-preset-es2015 is available')
+      t.end()
+    }, t.end)
+  })
+
+  test('bundleDependencies (fsevents@1.0.6)', function (t) {
+    prepare()
+    install(['fsevents@1.0.6'], { quiet: true })
+    .then(function () {
+      stat = fs.lstatSync(
+        join(process.cwd(), 'node_modules', 'fsevents', 'node_modules', '.bin', 'mkdirp'))
+      t.ok(stat.isSymbolicLink(), '.bin/mkdirp is available')
+
+      stat = fs.statSync(
+        join(process.cwd(), 'node_modules', 'fsevents', 'node_modules', '.bin', 'mkdirp'))
+      t.ok(stat.isFile(), '.bin/mkdirp refers to a file')
+      t.end()
+    }, t.end)
+  })
+
+  test('compiled modules (ursa@0.9.1)', function (t) {
+    if (!process.env.CI) {
+      t.skip('only ran on CI')
+      return t.end()
+    }
+
+    prepare()
+    install(['ursa@0.9.1'], { quiet: false })
+    .then(function () {
+      var ursa = require(join(process.cwd(), 'node_modules', 'ursa'))
+      t.ok(typeof ursa === 'object', 'ursa() is available')
+      t.end()
+    }, t.end)
+  })
+
+  test('tarballs (is-array-1.0.1.tgz)', function (t) {
+    prepare()
+    install(['http://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz'], { quiet: true })
+    .then(function () {
+      var isArray = require(
+        join(process.cwd(), 'node_modules', 'is-array'))
+
+      t.ok(isArray, 'isArray() is available')
+
+      stat = fs.statSync(
+        join(process.cwd(), 'node_modules', '.store',
+          'is-array-1.0.1#a83102a9c117983e6ff4d85311fb322231abe3d6'))
+      t.ok(stat.isDirectory(), 'stored in the proper location')
+      t.end()
+    }, t.end)
+  })
+
+  test('shrinkwrap compatibility', function (t) {
+    prepare()
+    fs.writeFileSync('package.json',
+      JSON.stringify({ dependencies: { rimraf: '*' } }),
+      'utf-8')
+
+    install(['rimraf@2.5.1'], { quiet: true })
+    .then(function () {
+      var npm = JSON.stringify(require.resolve('npm/bin/npm-cli.js'))
+      require('child_process').exec('node ' + npm + ' shrinkwrap', function (err) {
+        if (err) return t.end(err)
+        var wrap = JSON.parse(fs.readFileSync('npm-shrinkwrap.json', 'utf-8'))
+        t.ok(wrap.dependencies.rimraf.version === '2.5.1',
+          'npm shrinkwrap is successful')
+        t.end()
+      })
+    }, t.end)
+  })
+
+  test('save to package.json (rimraf@2.5.1)', function (t) {
+    prepare()
+    install(['rimraf@2.5.1'], { quiet: true, save: true })
+    .then(function () {
+      var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+      t.ok(typeof rimraf === 'function', 'rimraf() is available')
+
+      var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+      var dependencies = JSON.parse(pkgJson).dependencies
+      t.deepEqual(dependencies, {rimraf: '^2.5.1'}, 'rimraf has been added to dependencies')
 
       t.end()
     }, t.end)
-})
+  })
 
-test('production install (with production NODE_ENV)', function (t) {
-  var originalNODE_ENV = process.env.NODE_ENV
-  process.env.NODE_ENV = 'production'
-  prepare()
-  fs.writeFileSync('package.json', JSON.stringify(basicPackageJson), 'utf-8')
-
-  return install([], { quiet: true })
+  test('saveDev scoped module to package.json (@rstacruz/tap-spec)', function (t) {
+    prepare()
+    install(['@rstacruz/tap-spec'], { quiet: true, saveDev: true })
     .then(function () {
-      // reset NODE_ENV
-      process.env.NODE_ENV = originalNODE_ENV
+      var tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+      t.ok(typeof tapSpec === 'function', 'tapSpec() is available')
 
-      var rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
-
-      var tapStatErrCode
-      try {
-        fs.statSync(join(process.cwd(), 'node_modules', '@rstacruz'))
-      } catch (err) { tapStatErrCode = err.code }
-
-      t.ok(rimrafDir.isSymbolicLink, 'rimraf exists')
-      t.is(tapStatErrCode, 'ENOENT', 'tap-spec does not exist')
+      var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+      var devDependencies = JSON.parse(pkgJson).devDependencies
+      t.deepEqual(devDependencies, { '@rstacruz/tap-spec': '^4.1.1' }, 'tap-spec has been added to devDependencies')
 
       t.end()
     }, t.end)
-})
+  })
 
-function exists (path) {
-  try {
-    return fs.statSync(path)
-  } catch (err) {
-    if (err.code !== 'ENOENT') throw err
+  test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & rimraf@2.5.1) (in sorted order)', function (t) {
+    prepare()
+    install(['rimraf@2.5.1', '@rstacruz/tap-spec@latest'], { quiet: true, save: true, saveExact: true })
+    .then(function () {
+      var tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+      t.ok(typeof tapSpec === 'function', 'tapSpec() is available')
+
+      var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+      t.ok(typeof rimraf === 'function', 'rimraf() is available')
+
+      var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+      var dependencies = JSON.parse(pkgJson).dependencies
+      var expectedDeps = {
+        '@rstacruz/tap-spec': '4.1.1',
+        rimraf: '2.5.1'
+      }
+      t.deepEqual(dependencies, expectedDeps, 'tap-spec and rimraf have been added to dependencies')
+      t.deepEqual(Object.keys(dependencies), Object.keys(expectedDeps), 'tap-spec and rimraf have been added to dependencies in sorted order')
+
+      t.end()
+    }, t.end)
+  })
+
+  test('flattening symlinks (minimatch@3.0.0)', function (t) {
+    prepare()
+    install(['minimatch@3.0.0'], { quiet: true })
+    .then(function () {
+      stat = fs.lstatSync(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))
+      t.ok(stat.isSymbolicLink(), 'balanced-match is linked into store node_modules')
+
+      _ = exists(join(process.cwd(), 'node_modules', 'balanced-match'))
+      t.ok(!_, 'balanced-match is not linked into main node_modules')
+      t.end()
+    }, t.end)
+  })
+
+  test('flattening symlinks (minimatch + balanced-match)', function (t) {
+    prepare()
+    install(['minimatch@3.0.0'], { quiet: true })
+    .then(function () {
+      return install(['balanced-match@^0.3.0'], { quiet: true })
+    })
+    .then(function () {
+      _ = exists(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))
+      t.ok(!_, 'balanced-match is removed from store node_modules')
+
+      _ = exists(join(process.cwd(), 'node_modules', 'balanced-match'))
+      t.ok(_, 'balanced-match now in main node_modules')
+      t.end()
+    }, t.end)
+  })
+
+  test('production install (with --production flag)', function (t) {
+    prepare()
+    fs.writeFileSync('package.json', JSON.stringify(basicPackageJson), 'utf-8')
+
+    return install([], { quiet: true, production: true })
+      .then(function () {
+        var rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
+
+        var tapStatErrCode
+        try {
+          fs.statSync(join(process.cwd(), 'node_modules', '@rstacruz'))
+        } catch (err) { tapStatErrCode = err.code }
+
+        t.ok(rimrafDir.isSymbolicLink, 'rimraf exists')
+        t.is(tapStatErrCode, 'ENOENT', 'tap-spec does not exist')
+
+        t.end()
+      }, t.end)
+  })
+
+  test('production install (with production NODE_ENV)', function (t) {
+    var originalNODE_ENV = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    prepare()
+    fs.writeFileSync('package.json', JSON.stringify(basicPackageJson), 'utf-8')
+
+    return install([], { quiet: true })
+      .then(function () {
+        // reset NODE_ENV
+        process.env.NODE_ENV = originalNODE_ENV
+
+        var rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
+
+        var tapStatErrCode
+        try {
+          fs.statSync(join(process.cwd(), 'node_modules', '@rstacruz'))
+        } catch (err) { tapStatErrCode = err.code }
+
+        t.ok(rimrafDir.isSymbolicLink, 'rimraf exists')
+        t.is(tapStatErrCode, 'ENOENT', 'tap-spec does not exist')
+
+        t.end()
+      }, t.end)
+  })
+
+  function exists (path) {
+    try {
+      return fs.statSync(path)
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err
+    }
   }
-}
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,321 +1,319 @@
 var test = require('tape')
 var join = require('path').join
 var fs = require('fs')
+var caw = require('caw')
 var prepare = require('./support/prepare')
 var basicPackageJson = require('./support/simple-package.json')
 var install = require('../index').install
 
-var npm = require('npm')
-npm.load({}, () => {
-  if (!npm.config.get('http-proxy') && !npm.config.get('https-proxy')) {
-    require('./support/sepia')
-  }
+if (!caw()) {
+  require('./support/sepia')
+}
 
-  var stat, _
+var stat, _
 
-  test('eslint', require('tape-eslint')())
+test('eslint', require('tape-eslint')())
 
-  test('small with dependencies (rimraf)', function (t) {
-    prepare()
-    install(['rimraf@2.5.1'], { quiet: true })
-    .then(function () {
-      var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
-      t.ok(typeof rimraf === 'function', 'rimraf() is available')
+test('small with dependencies (rimraf)', function (t) {
+  prepare()
+  install(['rimraf@2.5.1'], { quiet: true })
+  .then(function () {
+    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+    t.ok(typeof rimraf === 'function', 'rimraf() is available')
 
-      stat = fs.lstatSync(join(process.cwd(), 'node_modules', '.bin', 'rimraf'))
-      t.ok(stat.isSymbolicLink(), '.bin/rimraf symlink is available')
+    stat = fs.lstatSync(join(process.cwd(), 'node_modules', '.bin', 'rimraf'))
+    t.ok(stat.isSymbolicLink(), '.bin/rimraf symlink is available')
 
-      stat = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf', 'bin.js'))
-      t.equal(stat.mode, parseInt('100755', 8), 'rimraf is executable')
-      t.ok(stat.isFile(), '.bin/rimraf refers to a file')
+    stat = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf', 'bin.js'))
+    t.equal(stat.mode, parseInt('100755', 8), 'rimraf is executable')
+    t.ok(stat.isFile(), '.bin/rimraf refers to a file')
 
-      t.end()
-    }, t.end)
-  })
-
-  test('no dependencies (lodash)', function (t) {
-    prepare()
-    install(['lodash@4.0.0'], { quiet: true })
-    .then(function () {
-      _ = require(join(process.cwd(), 'node_modules', 'lodash'))
-      t.ok(typeof _ === 'function', '_ is available')
-      t.ok(typeof _.clone === 'function', '_.clone is available')
-      t.end()
-    }, t.end)
-  })
-
-  test('scoped modules without version spec (@rstacruz/tap-spec)', function (t) {
-    prepare()
-    install(['@rstacruz/tap-spec'], { quiet: true })
-    .then(function () {
-      _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-      t.ok(typeof _ === 'function', 'tap-spec is available')
-      t.end()
-    }, t.end)
-  })
-
-  test('scoped modules with versions (@rstacruz/tap-spec@4.1.1)', function (t) {
-    prepare()
-    install(['@rstacruz/tap-spec@4.1.1'], { quiet: true })
-    .then(function () {
-      _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-      t.ok(typeof _ === 'function', 'tap-spec is available')
-      t.end()
-    }, t.end)
-  })
-
-  test('scoped modules (@rstacruz/tap-spec@*)', function (t) {
-    prepare()
-    install(['@rstacruz/tap-spec@*'], { quiet: true })
-    .then(function () {
-      _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-      t.ok(typeof _ === 'function', 'tap-spec is available')
-      t.end()
-    }, t.end)
-  })
-
-  test('multiple scoped modules (@rstacruz/...)', function (t) {
-    prepare()
-    install(['@rstacruz/tap-spec@*', '@rstacruz/travis-encrypt@*'], { quiet: true })
-    .then(function () {
-      _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-      t.ok(typeof _ === 'function', 'tap-spec is available')
-      _ = require(join(process.cwd(), 'node_modules', '@rstacruz/travis-encrypt'))
-      t.ok(typeof _ === 'function', 'travis-encrypt is available')
-      t.end()
-    }, t.end)
-  })
-
-  test('idempotency (rimraf)', function (t) {
-    prepare()
-    install(['rimraf@2.5.1'], { quiet: true })
-    .then(function () { return install([ 'rimraf@2.5.1' ], { quiet: true }) })
-    .then(function () {
-      var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
-      t.ok(typeof rimraf === 'function', 'rimraf is available')
-      t.end()
-    }, t.end)
-  })
-
-  test('overwriting (lodash@3.10.1 and @4.0.0)', function (t) {
-    prepare()
-    install(['lodash@3.10.1'], { quiet: true })
-    .then(function () { return install([ 'lodash@4.0.0' ], { quiet: true }) })
-    .then(function () {
-      _ = require(join(process.cwd(), 'node_modules', 'lodash', 'package.json'))
-      t.ok(_.version === '4.0.0', 'lodash is 4.0.0')
-      t.end()
-    }, t.end)
-  })
-
-  test('big with dependencies and circular deps (babel-preset-2015)', function (t) {
-    prepare()
-    install(['babel-preset-es2015@6.3.13'], { quiet: true })
-    .then(function () {
-      var b = require(join(process.cwd(), 'node_modules', 'babel-preset-es2015'))
-      t.ok(typeof b === 'object', 'babel-preset-es2015 is available')
-      t.end()
-    }, t.end)
-  })
-
-  test('bundleDependencies (fsevents@1.0.6)', function (t) {
-    prepare()
-    install(['fsevents@1.0.6'], { quiet: true })
-    .then(function () {
-      stat = fs.lstatSync(
-        join(process.cwd(), 'node_modules', 'fsevents', 'node_modules', '.bin', 'mkdirp'))
-      t.ok(stat.isSymbolicLink(), '.bin/mkdirp is available')
-
-      stat = fs.statSync(
-        join(process.cwd(), 'node_modules', 'fsevents', 'node_modules', '.bin', 'mkdirp'))
-      t.ok(stat.isFile(), '.bin/mkdirp refers to a file')
-      t.end()
-    }, t.end)
-  })
-
-  test('compiled modules (ursa@0.9.1)', function (t) {
-    if (!process.env.CI) {
-      t.skip('only ran on CI')
-      return t.end()
-    }
-
-    prepare()
-    install(['ursa@0.9.1'], { quiet: false })
-    .then(function () {
-      var ursa = require(join(process.cwd(), 'node_modules', 'ursa'))
-      t.ok(typeof ursa === 'object', 'ursa() is available')
-      t.end()
-    }, t.end)
-  })
-
-  test('tarballs (is-array-1.0.1.tgz)', function (t) {
-    prepare()
-    install(['http://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz'], { quiet: true })
-    .then(function () {
-      var isArray = require(
-        join(process.cwd(), 'node_modules', 'is-array'))
-
-      t.ok(isArray, 'isArray() is available')
-
-      stat = fs.statSync(
-        join(process.cwd(), 'node_modules', '.store',
-          'is-array-1.0.1#a83102a9c117983e6ff4d85311fb322231abe3d6'))
-      t.ok(stat.isDirectory(), 'stored in the proper location')
-      t.end()
-    }, t.end)
-  })
-
-  test('shrinkwrap compatibility', function (t) {
-    prepare()
-    fs.writeFileSync('package.json',
-      JSON.stringify({ dependencies: { rimraf: '*' } }),
-      'utf-8')
-
-    install(['rimraf@2.5.1'], { quiet: true })
-    .then(function () {
-      var npm = JSON.stringify(require.resolve('npm/bin/npm-cli.js'))
-      require('child_process').exec('node ' + npm + ' shrinkwrap', function (err) {
-        if (err) return t.end(err)
-        var wrap = JSON.parse(fs.readFileSync('npm-shrinkwrap.json', 'utf-8'))
-        t.ok(wrap.dependencies.rimraf.version === '2.5.1',
-          'npm shrinkwrap is successful')
-        t.end()
-      })
-    }, t.end)
-  })
-
-  test('save to package.json (rimraf@2.5.1)', function (t) {
-    prepare()
-    install(['rimraf@2.5.1'], { quiet: true, save: true })
-    .then(function () {
-      var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
-      t.ok(typeof rimraf === 'function', 'rimraf() is available')
-
-      var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-      var dependencies = JSON.parse(pkgJson).dependencies
-      t.deepEqual(dependencies, {rimraf: '^2.5.1'}, 'rimraf has been added to dependencies')
-
-      t.end()
-    }, t.end)
-  })
-
-  test('saveDev scoped module to package.json (@rstacruz/tap-spec)', function (t) {
-    prepare()
-    install(['@rstacruz/tap-spec'], { quiet: true, saveDev: true })
-    .then(function () {
-      var tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-      t.ok(typeof tapSpec === 'function', 'tapSpec() is available')
-
-      var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-      var devDependencies = JSON.parse(pkgJson).devDependencies
-      t.deepEqual(devDependencies, { '@rstacruz/tap-spec': '^4.1.1' }, 'tap-spec has been added to devDependencies')
-
-      t.end()
-    }, t.end)
-  })
-
-  test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & rimraf@2.5.1) (in sorted order)', function (t) {
-    prepare()
-    install(['rimraf@2.5.1', '@rstacruz/tap-spec@latest'], { quiet: true, save: true, saveExact: true })
-    .then(function () {
-      var tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
-      t.ok(typeof tapSpec === 'function', 'tapSpec() is available')
-
-      var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
-      t.ok(typeof rimraf === 'function', 'rimraf() is available')
-
-      var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-      var dependencies = JSON.parse(pkgJson).dependencies
-      var expectedDeps = {
-        '@rstacruz/tap-spec': '4.1.1',
-        rimraf: '2.5.1'
-      }
-      t.deepEqual(dependencies, expectedDeps, 'tap-spec and rimraf have been added to dependencies')
-      t.deepEqual(Object.keys(dependencies), Object.keys(expectedDeps), 'tap-spec and rimraf have been added to dependencies in sorted order')
-
-      t.end()
-    }, t.end)
-  })
-
-  test('flattening symlinks (minimatch@3.0.0)', function (t) {
-    prepare()
-    install(['minimatch@3.0.0'], { quiet: true })
-    .then(function () {
-      stat = fs.lstatSync(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))
-      t.ok(stat.isSymbolicLink(), 'balanced-match is linked into store node_modules')
-
-      _ = exists(join(process.cwd(), 'node_modules', 'balanced-match'))
-      t.ok(!_, 'balanced-match is not linked into main node_modules')
-      t.end()
-    }, t.end)
-  })
-
-  test('flattening symlinks (minimatch + balanced-match)', function (t) {
-    prepare()
-    install(['minimatch@3.0.0'], { quiet: true })
-    .then(function () {
-      return install(['balanced-match@^0.3.0'], { quiet: true })
-    })
-    .then(function () {
-      _ = exists(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))
-      t.ok(!_, 'balanced-match is removed from store node_modules')
-
-      _ = exists(join(process.cwd(), 'node_modules', 'balanced-match'))
-      t.ok(_, 'balanced-match now in main node_modules')
-      t.end()
-    }, t.end)
-  })
-
-  test('production install (with --production flag)', function (t) {
-    prepare()
-    fs.writeFileSync('package.json', JSON.stringify(basicPackageJson), 'utf-8')
-
-    return install([], { quiet: true, production: true })
-      .then(function () {
-        var rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
-
-        var tapStatErrCode
-        try {
-          fs.statSync(join(process.cwd(), 'node_modules', '@rstacruz'))
-        } catch (err) { tapStatErrCode = err.code }
-
-        t.ok(rimrafDir.isSymbolicLink, 'rimraf exists')
-        t.is(tapStatErrCode, 'ENOENT', 'tap-spec does not exist')
-
-        t.end()
-      }, t.end)
-  })
-
-  test('production install (with production NODE_ENV)', function (t) {
-    var originalNODE_ENV = process.env.NODE_ENV
-    process.env.NODE_ENV = 'production'
-    prepare()
-    fs.writeFileSync('package.json', JSON.stringify(basicPackageJson), 'utf-8')
-
-    return install([], { quiet: true })
-      .then(function () {
-        // reset NODE_ENV
-        process.env.NODE_ENV = originalNODE_ENV
-
-        var rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
-
-        var tapStatErrCode
-        try {
-          fs.statSync(join(process.cwd(), 'node_modules', '@rstacruz'))
-        } catch (err) { tapStatErrCode = err.code }
-
-        t.ok(rimrafDir.isSymbolicLink, 'rimraf exists')
-        t.is(tapStatErrCode, 'ENOENT', 'tap-spec does not exist')
-
-        t.end()
-      }, t.end)
-  })
-
-  function exists (path) {
-    try {
-      return fs.statSync(path)
-    } catch (err) {
-      if (err.code !== 'ENOENT') throw err
-    }
-  }
+    t.end()
+  }, t.end)
 })
+
+test('no dependencies (lodash)', function (t) {
+  prepare()
+  install(['lodash@4.0.0'], { quiet: true })
+  .then(function () {
+    _ = require(join(process.cwd(), 'node_modules', 'lodash'))
+    t.ok(typeof _ === 'function', '_ is available')
+    t.ok(typeof _.clone === 'function', '_.clone is available')
+    t.end()
+  }, t.end)
+})
+
+test('scoped modules without version spec (@rstacruz/tap-spec)', function (t) {
+  prepare()
+  install(['@rstacruz/tap-spec'], { quiet: true })
+  .then(function () {
+    _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+    t.ok(typeof _ === 'function', 'tap-spec is available')
+    t.end()
+  }, t.end)
+})
+
+test('scoped modules with versions (@rstacruz/tap-spec@4.1.1)', function (t) {
+  prepare()
+  install(['@rstacruz/tap-spec@4.1.1'], { quiet: true })
+  .then(function () {
+    _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+    t.ok(typeof _ === 'function', 'tap-spec is available')
+    t.end()
+  }, t.end)
+})
+
+test('scoped modules (@rstacruz/tap-spec@*)', function (t) {
+  prepare()
+  install(['@rstacruz/tap-spec@*'], { quiet: true })
+  .then(function () {
+    _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+    t.ok(typeof _ === 'function', 'tap-spec is available')
+    t.end()
+  }, t.end)
+})
+
+test('multiple scoped modules (@rstacruz/...)', function (t) {
+  prepare()
+  install(['@rstacruz/tap-spec@*', '@rstacruz/travis-encrypt@*'], { quiet: true })
+  .then(function () {
+    _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+    t.ok(typeof _ === 'function', 'tap-spec is available')
+    _ = require(join(process.cwd(), 'node_modules', '@rstacruz/travis-encrypt'))
+    t.ok(typeof _ === 'function', 'travis-encrypt is available')
+    t.end()
+  }, t.end)
+})
+
+test('idempotency (rimraf)', function (t) {
+  prepare()
+  install(['rimraf@2.5.1'], { quiet: true })
+  .then(function () { return install([ 'rimraf@2.5.1' ], { quiet: true }) })
+  .then(function () {
+    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+    t.ok(typeof rimraf === 'function', 'rimraf is available')
+    t.end()
+  }, t.end)
+})
+
+test('overwriting (lodash@3.10.1 and @4.0.0)', function (t) {
+  prepare()
+  install(['lodash@3.10.1'], { quiet: true })
+  .then(function () { return install([ 'lodash@4.0.0' ], { quiet: true }) })
+  .then(function () {
+    _ = require(join(process.cwd(), 'node_modules', 'lodash', 'package.json'))
+    t.ok(_.version === '4.0.0', 'lodash is 4.0.0')
+    t.end()
+  }, t.end)
+})
+
+test('big with dependencies and circular deps (babel-preset-2015)', function (t) {
+  prepare()
+  install(['babel-preset-es2015@6.3.13'], { quiet: true })
+  .then(function () {
+    var b = require(join(process.cwd(), 'node_modules', 'babel-preset-es2015'))
+    t.ok(typeof b === 'object', 'babel-preset-es2015 is available')
+    t.end()
+  }, t.end)
+})
+
+test('bundleDependencies (fsevents@1.0.6)', function (t) {
+  prepare()
+  install(['fsevents@1.0.6'], { quiet: true })
+  .then(function () {
+    stat = fs.lstatSync(
+      join(process.cwd(), 'node_modules', 'fsevents', 'node_modules', '.bin', 'mkdirp'))
+    t.ok(stat.isSymbolicLink(), '.bin/mkdirp is available')
+
+    stat = fs.statSync(
+      join(process.cwd(), 'node_modules', 'fsevents', 'node_modules', '.bin', 'mkdirp'))
+    t.ok(stat.isFile(), '.bin/mkdirp refers to a file')
+    t.end()
+  }, t.end)
+})
+
+test('compiled modules (ursa@0.9.1)', function (t) {
+  if (!process.env.CI) {
+    t.skip('only ran on CI')
+    return t.end()
+  }
+
+  prepare()
+  install(['ursa@0.9.1'], { quiet: false })
+  .then(function () {
+    var ursa = require(join(process.cwd(), 'node_modules', 'ursa'))
+    t.ok(typeof ursa === 'object', 'ursa() is available')
+    t.end()
+  }, t.end)
+})
+
+test('tarballs (is-array-1.0.1.tgz)', function (t) {
+  prepare()
+  install(['http://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz'], { quiet: true })
+  .then(function () {
+    var isArray = require(
+      join(process.cwd(), 'node_modules', 'is-array'))
+
+    t.ok(isArray, 'isArray() is available')
+
+    stat = fs.statSync(
+      join(process.cwd(), 'node_modules', '.store',
+        'is-array-1.0.1#a83102a9c117983e6ff4d85311fb322231abe3d6'))
+    t.ok(stat.isDirectory(), 'stored in the proper location')
+    t.end()
+  }, t.end)
+})
+
+test('shrinkwrap compatibility', function (t) {
+  prepare()
+  fs.writeFileSync('package.json',
+    JSON.stringify({ dependencies: { rimraf: '*' } }),
+    'utf-8')
+
+  install(['rimraf@2.5.1'], { quiet: true })
+  .then(function () {
+    var npm = JSON.stringify(require.resolve('npm/bin/npm-cli.js'))
+    require('child_process').exec('node ' + npm + ' shrinkwrap', function (err) {
+      if (err) return t.end(err)
+      var wrap = JSON.parse(fs.readFileSync('npm-shrinkwrap.json', 'utf-8'))
+      t.ok(wrap.dependencies.rimraf.version === '2.5.1',
+        'npm shrinkwrap is successful')
+      t.end()
+    })
+  }, t.end)
+})
+
+test('save to package.json (rimraf@2.5.1)', function (t) {
+  prepare()
+  install(['rimraf@2.5.1'], { quiet: true, save: true })
+  .then(function () {
+    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+    t.ok(typeof rimraf === 'function', 'rimraf() is available')
+
+    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    var dependencies = JSON.parse(pkgJson).dependencies
+    t.deepEqual(dependencies, {rimraf: '^2.5.1'}, 'rimraf has been added to dependencies')
+
+    t.end()
+  }, t.end)
+})
+
+test('saveDev scoped module to package.json (@rstacruz/tap-spec)', function (t) {
+  prepare()
+  install(['@rstacruz/tap-spec'], { quiet: true, saveDev: true })
+  .then(function () {
+    var tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+    t.ok(typeof tapSpec === 'function', 'tapSpec() is available')
+
+    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    var devDependencies = JSON.parse(pkgJson).devDependencies
+    t.deepEqual(devDependencies, { '@rstacruz/tap-spec': '^4.1.1' }, 'tap-spec has been added to devDependencies')
+
+    t.end()
+  }, t.end)
+})
+
+test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & rimraf@2.5.1) (in sorted order)', function (t) {
+  prepare()
+  install(['rimraf@2.5.1', '@rstacruz/tap-spec@latest'], { quiet: true, save: true, saveExact: true })
+  .then(function () {
+    var tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+    t.ok(typeof tapSpec === 'function', 'tapSpec() is available')
+
+    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+    t.ok(typeof rimraf === 'function', 'rimraf() is available')
+
+    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    var dependencies = JSON.parse(pkgJson).dependencies
+    var expectedDeps = {
+      '@rstacruz/tap-spec': '4.1.1',
+      rimraf: '2.5.1'
+    }
+    t.deepEqual(dependencies, expectedDeps, 'tap-spec and rimraf have been added to dependencies')
+    t.deepEqual(Object.keys(dependencies), Object.keys(expectedDeps), 'tap-spec and rimraf have been added to dependencies in sorted order')
+
+    t.end()
+  }, t.end)
+})
+
+test('flattening symlinks (minimatch@3.0.0)', function (t) {
+  prepare()
+  install(['minimatch@3.0.0'], { quiet: true })
+  .then(function () {
+    stat = fs.lstatSync(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))
+    t.ok(stat.isSymbolicLink(), 'balanced-match is linked into store node_modules')
+
+    _ = exists(join(process.cwd(), 'node_modules', 'balanced-match'))
+    t.ok(!_, 'balanced-match is not linked into main node_modules')
+    t.end()
+  }, t.end)
+})
+
+test('flattening symlinks (minimatch + balanced-match)', function (t) {
+  prepare()
+  install(['minimatch@3.0.0'], { quiet: true })
+  .then(function () {
+    return install(['balanced-match@^0.3.0'], { quiet: true })
+  })
+  .then(function () {
+    _ = exists(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))
+    t.ok(!_, 'balanced-match is removed from store node_modules')
+
+    _ = exists(join(process.cwd(), 'node_modules', 'balanced-match'))
+    t.ok(_, 'balanced-match now in main node_modules')
+    t.end()
+  }, t.end)
+})
+
+test('production install (with --production flag)', function (t) {
+  prepare()
+  fs.writeFileSync('package.json', JSON.stringify(basicPackageJson), 'utf-8')
+
+  return install([], { quiet: true, production: true })
+    .then(function () {
+      var rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
+
+      var tapStatErrCode
+      try {
+        fs.statSync(join(process.cwd(), 'node_modules', '@rstacruz'))
+      } catch (err) { tapStatErrCode = err.code }
+
+      t.ok(rimrafDir.isSymbolicLink, 'rimraf exists')
+      t.is(tapStatErrCode, 'ENOENT', 'tap-spec does not exist')
+
+      t.end()
+    }, t.end)
+})
+
+test('production install (with production NODE_ENV)', function (t) {
+  var originalNODE_ENV = process.env.NODE_ENV
+  process.env.NODE_ENV = 'production'
+  prepare()
+  fs.writeFileSync('package.json', JSON.stringify(basicPackageJson), 'utf-8')
+
+  return install([], { quiet: true })
+    .then(function () {
+      // reset NODE_ENV
+      process.env.NODE_ENV = originalNODE_ENV
+
+      var rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
+
+      var tapStatErrCode
+      try {
+        fs.statSync(join(process.cwd(), 'node_modules', '@rstacruz'))
+      } catch (err) { tapStatErrCode = err.code }
+
+      t.ok(rimrafDir.isSymbolicLink, 'rimraf exists')
+      t.is(tapStatErrCode, 'ENOENT', 'tap-spec does not exist')
+
+      t.end()
+    }, t.end)
+})
+
+function exists (path) {
+  try {
+    return fs.statSync(path)
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err
+  }
+}


### PR DESCRIPTION
By simply using 'caw' module to create the HTTP agent with proxy settings
we are able to use 'pnpm' behind a basic corporate proxy (I could not test
it extensively on any kind of proxy).

I had to disable 'sepia' caching in case a proxy configuration is found
because it was not behaving fine with the new HTTP agent setup.
