### PR TITLE
Fix issue #78 ?

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -218,8 +218,13 @@ function buildInStore (ctx, paths, pkg, log) {
 
     // move to .store/lodash@4.0.0; remove the stub done earlier
     .then(_ => fs.unlink(join(paths.tmp, '.pnpm_inprogress')))
-    .then(_ => fs.unlink(paths.target))
-    .then(_ => fs.rename(paths.tmp, paths.target))
+    // we need to make sure that symlinkToModules for another project dependent
+    // on this package will not get called inbetween `unlink` and `rename`
+    // the easiest way to achieve this is to make them synchronous
+    .then(_ => {
+      fs.unlinkSync(paths.target)
+      fs.renameSync(paths.tmp, paths.target)
+    })
 }
 
 function installLogger (log, pkg) {


### PR DESCRIPTION
I _think_ I may have found the cause of #78 - and if I'm right then here's a quick fix. It's kinda hard to be sure since I couldn't recreate at will - although I could recreate it quite frequently on certain repos and haven't seen it on them since. I imagine that there are other non-sync ways of fixing the problem - but I haven't really looked that far.

Ideas:

 - maybe only make the `unlink` call synchronous
 - turn the `unlink` => `rename` chain into a promise that the `symlinkToModules` of dependents must wait for
 - change `symlinkToModules` so it doesn't care if the rename is complete (would anything else downstream care either?)