### PR TITLE
print more consumer friendly error, when there is no ./package.json

### DIFF
--- a/lib/cmd/install.js
+++ b/lib/cmd/install.js
@@ -26,6 +26,7 @@ function installCmd (input, flags) {
 
   return readPkgUp()
     .then(_ => { pkg = _ })
+    .then(_ => pkg.path ? _ : Promise.reject("there is no './package.json'"))
     .then(_ => updateContext(pkg.path))
     .then(_ => install())
     .then(_ => linkPeers(pkg, ctx.store, ctx.installs))


### PR DESCRIPTION
was not sure to exit with 0, while it still an error, 'cause then this error can be swallowed in someone CI build, which i personally want to avoid