### PR TITLE
Send auth token if one exists for registry (#167, #105)

### DIFF
--- a/lib/got.js
+++ b/lib/got.js
@@ -7,6 +7,7 @@ var config = require('./config')
 var HttpAgent = require('http').Agent
 var HttpsAgent = require('https').Agent
 var caw = require('caw')
+var getAuthToken = require('registry-auth-token')
 
 var cache = {}
 
@@ -70,6 +71,13 @@ function extend (url, options) {
   if (!options) options = {}
   if (url.indexOf('https://') === 0) {
     options.agent = caw() || httpsKeepaliveAgent
+
+    var authToken = getAuthToken(url, {recursive: true})
+    if (authToken) {
+      options.headers = assign({}, options.headers || {}, {
+        authorization: 'Bearer ' + authToken
+      })
+    }
   } else {
     options.agent = caw() || httpKeepaliveAgent
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "observatory": "1.0.0",
     "rc": "1.1.6",
     "read-pkg-up": "1.0.1",
+    "registry-auth-token": "^1.1.0",
     "registry-url": "3.0.3",
     "rimraf": "2.5.2",
     "semver": "5.1.0",


### PR DESCRIPTION
**TL;DR:  This adds the auth token for requests to registries that npm already knows about. In other words, do an `npm adduser` first, then use pnpm as you normally would.**

Hi!

We're using a private Sinopia registry where I work, which requires authentication. Right now, pnpm can't be used in projects where we have a mixture of "external" and "internal" dependencies, because it doesn't send any auth info (which results in the registry sending a 403).

I've made a simple module that extracts the auth token set in `.npmrc` (if one exists) and added that as a dependency. I couldn't quite make out the official client signs requests and in which cases `always-auth` is used. For our internal registry, I have *not* set `always-auth`, yet it still authenticates GET-requests. So for now, I'm just always sending the auth token, if it exists.

I also didn't want to send the auth token if the client isn't communicating over HTTPS, since that would be pretty insecure. Not sure if there should be some sort of setting for being able to send it even over HTTP - feedback is welcome.