### PR TITLE
Install: do symlinks synchronously

### DIFF
--- a/lib/fs/force_symlink.js
+++ b/lib/fs/force_symlink.js
@@ -13,8 +13,11 @@ function forceSymlink (srcPath, dstPath, type, cb) {
   debug('%s -> %s', srcPath, dstPath)
   type = typeof type === 'string' ? type : null
   cb = arguments[arguments.length - 1] || function () {}
-  fs.symlink(srcPath, dstPath, type, function (err) {
-    if (!err || err.code !== 'EEXIST') return cb(err)
+  try {
+    fs.symlinkSync(srcPath, dstPath, type)
+    cb()
+  } catch (err) {
+    if (err.code !== 'EEXIST') return cb(err)
 
     fs.readlink(dstPath, function (err, linkString) {
       if (err || srcPath === linkString) return cb(err)
@@ -24,7 +27,7 @@ function forceSymlink (srcPath, dstPath, type, cb) {
         forceSymlink(srcPath, dstPath, cb)
       })
     })
-  })
+  }
 }
 
 module.exports = thenify(forceSymlink)


### PR DESCRIPTION
This should fix @rexxar's report here: https://github.com/rstacruz/pnpm/pull/138#issuecomment-205717593

In moving from `fs.symlink` to `fs.symlinkSync`, we missed one other call to fs.symlink(). This fixes that.