### PR TITLE
Resolve hosted github packages

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -1,5 +1,6 @@
 var resolveNpm = require('./resolve/npm')
 var resolveTarball = require('./resolve/tarball')
+var resolveGithub = require('./resolve/github')
 
 /**
  * Resolves a package in the NPM registry. Done as part of `install()`.
@@ -20,6 +21,8 @@ module.exports = function resolve (pkg, log) {
     return resolveNpm(pkg, log)
   } else if (pkg.type === 'remote') {
     return resolveTarball(pkg, log)
+  } else if (pkg.type === 'hosted' && pkg.hosted.type === 'github') {
+    return resolveGithub(pkg, log)
   } else {
     throw new Error('' + pkg.rawSpec + ': ' + pkg.type + ' packages not supported')
   }

--- a/lib/resolve/github.js
+++ b/lib/resolve/github.js
@@ -1,0 +1,75 @@
+var got = require('../got')
+
+/**
+ * Resolves a 'hosted' package hosted on 'github'.
+ */
+
+var PARSE_GITHUB_RE = /^github:([^\/]+)\/([^#]+)(#(.+))?$/
+
+module.exports = function resolveGithub (pkg) {
+  var spec = parseGithubSpec(pkg)
+  return resolveRef(spec).then(function (ref) {
+    spec.ref = ref
+    return resolvePackageName(spec).then(function (name) {
+      var fullname = name + ['@github', spec.owner, spec.repo, spec.ref].join('!')
+      return {
+        name: name,
+        fullname: fullname,
+        dist: {
+          tarball: [
+            'https://api.github.com/repos',
+            spec.owner,
+            spec.repo,
+            'tarball',
+            spec.ref
+          ].join('/')
+        }
+      }
+    })
+  })
+}
+
+function resolvePackageName (spec) {
+  var url = [
+    'https://api.github.com/repos',
+    spec.owner,
+    spec.repo,
+    'contents/package.json?ref=' + spec.ref
+  ].join('/')
+  return getJSON(url).then(function (body) {
+    var content = new Buffer(body.content, 'base64').toString('utf8')
+    var pkg = JSON.parse(content)
+    return pkg.name
+  })
+}
+
+function resolveRef (spec) {
+  var url = [
+    'https://api.github.com/repos',
+    spec.owner,
+    spec.repo,
+    'commits',
+    spec.ref
+  ].join('/')
+  return getJSON(url).then(function (body) { return body.sha })
+}
+
+function getJSON (url) {
+  return got.get(url)
+    .then(function (res) { return res.promise })
+    .then(function (res) {
+      var body = JSON.parse(res.body)
+      return body
+    })
+}
+
+function parseGithubSpec (pkg) {
+  var m = PARSE_GITHUB_RE.exec(pkg.hosted.shortcut)
+  if (!m) {
+    throw new Error('cannot parse: ' + pkg.hosted.shortcut)
+  }
+  var owner = m[1]
+  var repo = m[2]
+  var ref = m[4] || 'HEAD'
+  return {owner: owner, repo: repo, ref: ref}
+}


### PR DESCRIPTION
This PR adds support for resolving packages hosted on GitHub. It calls GH API first to resolve reference to a commmit SHA, then uses it to fetch `package.json` (to know which package name it is) and then to generate link to a tarball.

Let me know if I'm missing something and what should I do so functionality is merged into pnpm.

P.S. Thanks for pnpm, this is a huge improvement over official `npm install`