### PR TITLE
Fix issue with installing nested scoped packages

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -248,8 +248,12 @@ function symlinkSelf (target, pkg, depth) {
     return mkdirp(join(target, 'node_modules'))
       .then(_ => symlink(
         join('..', '_'),
-        join(target, 'node_modules', pkg.name)))
+        join(target, 'node_modules', escapeName(pkg.name))))
   }
+}
+
+function escapeName (name) {
+  return name && name.replace('/', '%2f')
 }
 
 /*

--- a/lib/install/link_peers.js
+++ b/lib/install/link_peers.js
@@ -31,11 +31,10 @@ module.exports = function linkPeers (pkg, store, installs) {
       return unsymlink(join(modules, roots[name].name))
     })))
     .then(_ => Promise.all(Object.keys(peers).map(name =>
-      unsymlink(join(modules, peers[name].name))
+      unsymlink(join(modules, peers[name].spec.escapedName))
       .then(_ =>
         relSymlink(
           join(store, peers[name].fullname, '_'),
-          join(modules, peers[name].name)))
+          join(modules, peers[name].spec.escapedName)))
     )))
 }
-

--- a/test/index.js
+++ b/test/index.js
@@ -85,6 +85,16 @@ test('multiple scoped modules (@rstacruz/...)', function (t) {
   }, t.end)
 })
 
+test('nested scoped modules (test-pnpm-issue219 -> @zkochan/test-pnpm-issue219)', function (t) {
+  prepare()
+  install(['test-pnpm-issue219@1.0.2'], { quiet: true })
+  .then(function () {
+    _ = require(join(process.cwd(), 'node_modules', 'test-pnpm-issue219'))
+    t.ok(_ === 'test-pnpm-issue219,@zkochan/test-pnpm-issue219', 'nested scoped package is available')
+    t.end()
+  }, t.end)
+})
+
 test('idempotency (rimraf)', function (t) {
   prepare()
   install(['rimraf@2.5.1'], { quiet: true })


### PR DESCRIPTION
When a dependency is dependent on a scoped package, there is an error during installation. I was able to reproduce it via a test and then fix it.

close #219