### PR TITLE
run postinstall and prepublish after installation

### DIFF
--- a/lib/cmd/install.js
+++ b/lib/cmd/install.js
@@ -4,6 +4,7 @@ var join = require('path').join
 var resolve = require('path').resolve
 var assign = require('object-assign')
 var npa = require('npm-package-arg')
+var spawnSync = require('cross-spawn').sync
 
 var logger = require('../logger')
 var installMultiple = require('../install_multiple')
@@ -30,6 +31,7 @@ function installCmd (input, flags) {
     .then(_ => updateContext(pkg.path))
     .then(_ => install())
     .then(_ => linkPeers(pkg, ctx.store, ctx.installs))
+    .then(_ => mainPostInstall())
 
   function install () {
     installType = input && input.length ? 'named' : 'general'
@@ -63,6 +65,24 @@ function installCmd (input, flags) {
       var inputNames = input.map(pkgName => npa(pkgName).name)
       var savedPackages = packages.filter(pkg => inputNames.indexOf(pkg.name) > -1)
       return save(pkg, savedPackages, saveType, flags.saveExact)
+    }
+  }
+
+  function mainPostInstall () {
+    var scripts = pkg.pkg.scripts || {}
+    if (scripts.postinstall) runScript('postinstall')
+    if (!isProductionInstall && scripts.prepublish) runScript('prepublish')
+    return
+
+    function runScript (scriptName) {
+      var result = spawnSync('npm', ['run', scriptName], {
+        cwd: dirname(pkg.path),
+        stdio: 'inherit'
+      })
+      if (result.status !== 0) {
+        process.exit(result.status)
+        return
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "caw": "1.2.0",
     "chalk": "1.1.3",
     "commondir": "1.0.1",
+    "cross-spawn": "^4.0.0",
     "debug": "2.2.0",
     "got": "5.4.1",
     "gunzip-maybe": "1.3.1",


### PR DESCRIPTION
close #50

cross-spawn used for executing the npm commands. There were problems on Windows when running `npm run` by `child_process.spawnSync`