### PR TITLE
Run install scripts via npm

### DIFF
--- a/lib/install/post_install.js
+++ b/lib/install/post_install.js
@@ -13,9 +13,18 @@ module.exports = function postInstall (root_, pkg, log) {
   var scripts = pkg && pkg.scripts || {}
   return Promise.resolve()
     .then(_ => !scripts.install && checkBindingGyp(root, log))
-    .then(_ => runScript(root, scripts.preinstall, log))
-    .then(_ => runScript(root, scripts.install, log))
-    .then(_ => runScript(root, scripts.postinstall, log))
+    .then(_ => {
+      if (scripts.install) {
+        return npmRunScript('install')
+      }
+      return npmRunScript('preinstall')
+        .then(_ => npmRunScript(scripts.postinstall))
+    })
+
+  function npmRunScript (scriptName) {
+    if (!scriptName || !scripts[scriptName]) return Promise.resolve()
+    return runScript(root, 'npm run ' + scriptName, log)
+  }
 }
 
 /*


### PR DESCRIPTION
npm is setting a bunch of environment variables that might be used by the installed package's scripts. Therefore the package scripts have to be always executed by the npm CLI.

fix #168