### PR TITLE
Use junctions on Windows

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,13 +5,16 @@
 - [#258] - Improve support for Windows. ([#259], [@zkochan])
 - [#262] - Improve support for build scripts that use npm config variables. ([@zkochan])
 - [#265] - Respect configuration from `.npmrc`. ([@zkochan])
+- [#6] - Use junctions on Windows. ([#269], [@zkochan])
 
+[#6]: https://github.com/rstacruz/pnpm/issues/6
 [#21]: https://github.com/rstacruz/pnpm/issues/21
 [#257]: https://github.com/rstacruz/pnpm/issues/257
 [#258]: https://github.com/rstacruz/pnpm/issues/258
 [#259]: https://github.com/rstacruz/pnpm/issues/259
 [#262]: https://github.com/rstacruz/pnpm/issues/262
 [#265]: https://github.com/rstacruz/pnpm/issues/265
+[#269]: https://github.com/rstacruz/pnpm/issues/269
 [v0.25.0]: https://github.com/rstacruz/pnpm/compare/v0.24.0...v0.25.0
 
 ## [v0.24.0]

--- a/lib/fs/force_symlink.js
+++ b/lib/fs/force_symlink.js
@@ -11,8 +11,6 @@ var debug = require('debug')('pnpm:symlink')
 
 function forceSymlink (srcPath, dstPath, type, cb) {
   debug('%s -> %s', srcPath, dstPath)
-  type = typeof type === 'string' ? type : null
-  cb = arguments[arguments.length - 1] || function () {}
   try {
     fs.symlinkSync(srcPath, dstPath, type)
     cb()
@@ -24,7 +22,7 @@ function forceSymlink (srcPath, dstPath, type, cb) {
 
       fs.unlink(dstPath, function (err) {
         if (err) return cb(err)
-        forceSymlink(srcPath, dstPath, cb)
+        forceSymlink(srcPath, dstPath, type, cb)
       })
     })
   }

--- a/lib/fs/rel_symlink.js
+++ b/lib/fs/rel_symlink.js
@@ -1,15 +1,19 @@
 var symlink = require('./force_symlink')
 var dirname = require('path').dirname
 var relative = require('path').relative
+var os = require('os')
+
+// Always use "junctions" on Windows. Even though support for "symbolic links" was added in Vista+, users by default
+// lack permission to create them
+var symlinkType = os.platform() === 'win32' ? 'junction' : 'dir'
 
 /*
  * Relative symlink
  */
 
 module.exports = function relSymlink (src, dest) {
-  // Turn it into a relative path when not in win32.
-  var isWindows = process.platform === 'win32'
-  var rel = isWindows ? src : relative(dirname(dest), src)
+  // Junction points can't be relative
+  var rel = symlinkType !== 'junction' ? relative(dirname(dest), src) : src
 
-  return symlink(rel, dest, 'junction')
+  return symlink(rel, dest, symlinkType)
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -13,7 +13,6 @@ var fetch = require('./fetch')
 var resolve = require('./resolve')
 
 var mkdirp = require('./fs/mkdirp')
-var symlink = require('./fs/force_symlink')
 var obliterate = require('./fs/obliterate')
 var requireJson = require('./fs/require_json')
 var relSymlink = require('./fs/rel_symlink')
@@ -179,7 +178,7 @@ function fetchToStore (ctx, paths, pkg, log) {
     // so that when any other module requires it, it's available even
     // if it's partially built
     .then(_ => mkdirp(dirname(paths.target)))
-    .then(_ => symlink(paths.tmp, paths.target))
+    .then(_ => relSymlink(paths.tmp, paths.target))
 
     // download and untar
     .then(_ => log('download-queued'))
@@ -248,7 +247,7 @@ function symlinkSelf (target, pkg, depth) {
     return Promise.resolve()
   } else {
     return mkdirp(join(target, 'node_modules'))
-      .then(_ => symlink(
+      .then(_ => relSymlink(
         join('..', '_'),
         join(target, 'node_modules', escapeName(pkg.name))))
   }


### PR DESCRIPTION
close #6

Checked on Windows 10. After these changes admin permissions are not needed for pnpm to work.