### PR TITLE
add support for Basic Auth (registry-auth-token@3.0.0)

### DIFF
--- a/lib/got.js
+++ b/lib/got.js
@@ -79,7 +79,7 @@ function extend (url, options) {
     var authToken = getAuthToken(url, {recursive: true})
     if (authToken) {
       options.headers = assign({}, options.headers || {}, {
-        authorization: 'Bearer ' + authToken
+        authorization: authToken.type + ' ' + authToken.token
       })
     }
   } else {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "observatory": "1.0.0",
     "rc": "1.1.6",
     "read-pkg-up": "1.0.1",
-    "registry-auth-token": "2.1.1",
+    "registry-auth-token": "3.0.0",
     "registry-url": "3.1.0",
     "rimraf": "2.5.4",
     "semver": "5.3.0",


### PR DESCRIPTION
There is still an internal bug in rexxars/registry-auth-token#6,
but it just hits a very special use case and should also exist in 2.1.1.

So if 2.1.1 works for you, 3.0.0 should work as well.

resolves #270 #277