### PR TITLE
Fix store-path property usage from the configs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ## [v0.25.0]
 > Unreleased
 
+- **Breaking** - the API expects `opts.storePath` instead of `opts.store_path`.
 - [#21] - Support installing from files. ([#257], [@zkochan])
 - [#258] - Improve support for Windows. ([#259], [@zkochan])
 - [#262] - Improve support for build scripts that use npm config variables. ([@zkochan])

--- a/lib/cmd/install.js
+++ b/lib/cmd/install.js
@@ -21,7 +21,7 @@ var runtimeError = require('../runtime_error')
 function installCmd (input, opts) {
   opts = Object.assign({}, opts, {
     concurrency: 16,
-    store_path: 'node_modules/.store',
+    storePath: 'node_modules/.store',
     logger: 'pretty'
   })
   process.env.pnpm_config_concurrency = opts.concurrency
@@ -61,7 +61,7 @@ function installCmd (input, opts) {
   function updateContext (packageJson) {
     var root = packageJson ? dirname(packageJson) : process.cwd()
     ctx.root = root
-    ctx.store = resolve(root, opts.store_path)
+    ctx.store = resolve(root, opts.storePath)
     if (!opts.quiet) ctx.log = logger(opts.logger)
     else ctx.log = function () { return function () {} }
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,5 @@
 module.exports = require('rc')('pnpm', {
   concurrency: 16,
-  store_path: 'node_modules/.store',
+  storePath: 'node_modules/.store',
   logger: 'pretty'
 })


### PR DESCRIPTION
During implementation of #166 `camelcase-keys` was used to convert configs to camelcase function options and the underscored store_path option was not updated.