### PR TITLE
Allow JSON cache to be emptied

### DIFF
--- a/lib/fs/require_json.js
+++ b/lib/fs/require_json.js
@@ -10,3 +10,7 @@ module.exports = function requireJson (path) {
   cache[path] = JSON.parse(require('fs').readFileSync(path, 'utf-8'))
   return cache[path]
 }
+
+module.exports.emptyCache = function emptyCache() {
+  cache = {};
+}

--- a/lib/fs/require_json.js
+++ b/lib/fs/require_json.js
@@ -11,6 +11,6 @@ module.exports = function requireJson (path) {
   return cache[path]
 }
 
-module.exports.emptyCache = function emptyCache() {
-  cache = {};
+module.exports.emptyCache = function emptyCache () {
+  cache = {}
 }


### PR DESCRIPTION
I'm using pnpm programmatically in a long running process. If the package.json is edited by a different apps/process then it causes a mismatch and strange things tend to happen.

This provides an escape hatch in those circumstances.