### PR TITLE
Use pnpm for installing its own dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ cache:
   directories:
     - node_modules
 sudo: false
+before_install:
+  - npm install -g pnpm
+install:
+  - pnpm install --quiet
 script:
   - npm test
   - if [[ $TRAVIS_NODE_VERSION == "4" ]]; then npm run docs:build; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,8 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm set fetch-retry-maxtimeout 180000
-  - npm install || (timeout 30 && npm install)
+  - npm install -g pnpm
+  - pnpm install --quiet
 matrix:
   fast_finish: true
 build: off


### PR DESCRIPTION
This is crazy but pnpm can be used to install the dependencies for itself!

This is a nice additional check for the latest version of pnpm.