### PR TITLE
Publish an alternative version of pnpm with bundled dependencies

### DIFF
--- a/.scripts/hide_deps.js
+++ b/.scripts/hide_deps.js
@@ -2,6 +2,7 @@
 const renameKey = require('./rename_key')
 
 renameKey({
+  pkgName: 'pnpm-rocket',
   currentKeyName: 'dependencies',
   newKeyName: '__dependencies',
   addPreinstall: true

--- a/.scripts/release.sh
+++ b/.scripts/release.sh
@@ -10,19 +10,25 @@ echo "install just the dependencies and don't run any pre/post install scripts";
 npm install --production --ignore-scripts;
 set +e;
 
+publish () {
+  if [[ $1 ]]; then
+    npm publish --tag $1;
+  else
+    npm publish;
+  fi
+}
+
+echo "publish pnpm $1";
+publish;
+
 echo "rename node_modules to cached_node_modules";
 node .scripts/rename node_modules cached_node_modules;
 
 echo "remove the dependencies section from package.json";
 node .scripts/hide_deps;
 
-echo "publish $1";
-
-if [[ $1 ]]; then
-  npm publish --tag $1;
-else
-  npm publish;
-fi
+echo "publish pnpm-rocket $1";
+publish;
 
 echo "return the dependencies section to package.json";
 node .scripts/unhide_deps;

--- a/.scripts/rename_key.js
+++ b/.scripts/rename_key.js
@@ -12,7 +12,7 @@ module.exports = opts => {
   for (let i = 0; i < keys.length; i++) {
     if (keys[i] === 'scripts') {
       newPkgJSON.scripts = pkgJSON.scripts
-      if (opts.addPreinstall) {
+      if (opts.pkgName === 'pnpm-rocket') {
         newPkgJSON.scripts.preinstall = 'node .scripts/rename cached_node_modules node_modules'
         continue
       }
@@ -25,6 +25,7 @@ module.exports = opts => {
     }
     newPkgJSON[keys[i]] = pkgJSON[keys[i]]
   }
+  newPkgJSON.name = opts.pkgName
 
   fs.writeFileSync(pkgPath, JSON.stringify(newPkgJSON, null, 2), 'UTF8')
 }

--- a/.scripts/rename_key.js
+++ b/.scripts/rename_key.js
@@ -1,6 +1,7 @@
 'use strict'
 const fs = require('fs')
 const path = require('path')
+const eof = require('os').EOL
 
 module.exports = opts => {
   const pkgPath = path.resolve(process.cwd(), 'package.json')
@@ -27,5 +28,5 @@ module.exports = opts => {
   }
   newPkgJSON.name = opts.pkgName
 
-  fs.writeFileSync(pkgPath, JSON.stringify(newPkgJSON, null, 2), 'UTF8')
+  fs.writeFileSync(pkgPath, JSON.stringify(newPkgJSON, null, 2) + eof, 'UTF8')
 }

--- a/.scripts/unhide_deps.js
+++ b/.scripts/unhide_deps.js
@@ -2,6 +2,7 @@
 const renameKey = require('./rename_key')
 
 renameKey({
+  pkgName: 'pnpm',
   currentKeyName: '__dependencies',
   newKeyName: 'dependencies',
   addPreinstall: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - 6
 sudo: false
 before_install:
-  - npm install -g pnpm
+  - npm install -g pnpm-rocket
 install:
   - pnpm install
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm set fetch-retry-maxtimeout 180000
-  - npm install -g pnpm
+  - npm install -g pnpm-rocket
   - pnpm install
 matrix:
   fast_finish: true


### PR DESCRIPTION
If it will be decided that https://github.com/rstacruz/pnpm/pull/310 is too risky, this solution can be used. This solution doesn't make any changes in how pnpm is currently being installed and how it works, but it publishes every time pnpm is published and alternative version which has an improved installation speed.