### PR TITLE
bin files are used once they were created

### DIFF
--- a/lib/install/link_bins.js
+++ b/lib/install/link_bins.js
@@ -17,9 +17,11 @@ module.exports = linkAllBins
 module.exports.linkPkgBins = linkPkgBins
 
 function linkAllBins (modules) {
-  getDirectories(modules)
-    .reduce((pkgDirs, dir) => pkgDirs.concat(isScopedPkgsDir(dir) ? getDirectories(dir) : dir), [])
-    .forEach(pkgDir => linkPkgBins(modules, pkgDir))
+  return Promise.all(
+    getDirectories(modules)
+      .reduce((pkgDirs, dir) => pkgDirs.concat(isScopedPkgsDir(dir) ? getDirectories(dir) : dir), [])
+      .map(pkgDir => linkPkgBins(modules, pkgDir))
+  )
 }
 
 function getDirectories (srcPath) {


### PR DESCRIPTION
I've noticed this issue after we've started to use pnpm to install pnpm deps. The build was failing too frequently on appveyor.

link_bins was not returning a Promise. As a consequence the linking step was being completed too early and the next step was trying to use the bin files which were not yet created.

I think this bug is a pretty old one. Might fix some of the open issues.