### PR TITLE
style: use more ES6 syntax

### DIFF
--- a/bin/pnpm.js
+++ b/bin/pnpm.js
@@ -72,7 +72,7 @@ function run (argv) {
     }
   })
 
-  var opts = Object.assign({}, getRC('npm'), getRC('pnpm'))
+  const opts = Object.assign({}, getRC('npm'), getRC('pnpm'))
 
   // This is needed because the arg values should be used only if they were passed
   Object.keys(cli.flags).forEach(key => {

--- a/lib/api/init_cmd.js
+++ b/lib/api/init_cmd.js
@@ -1,26 +1,26 @@
 'use strict'
-var readPkgUp = require('read-pkg-up')
-var resolve = require('path').resolve
-var dirname = require('path').dirname
-var thenify = require('thenify')
-var lock = thenify(require('lockfile').lock)
-var unlock = thenify(require('lockfile').unlock)
-var requireJson = require('../fs/require_json')
-var writeJson = require('../fs/write_json')
-var expandTilde = require('../fs/expand_tilde')
+const readPkgUp = require('read-pkg-up')
+const resolve = require('path').resolve
+const dirname = require('path').dirname
+const thenify = require('thenify')
+const lock = thenify(require('lockfile').lock)
+const unlock = thenify(require('lockfile').unlock)
+const requireJson = require('../fs/require_json')
+const writeJson = require('../fs/write_json')
+const expandTilde = require('../fs/expand_tilde')
 const resolveGlobalPkgPath = require('../resolve_global_pkg_path')
 
-var logger = require('../logger')
-var storeJsonController = require('../fs/store_json_controller')
-var mkdirp = require('../fs/mkdirp')
+const logger = require('../logger')
+const storeJsonController = require('../fs/store_json_controller')
+const mkdirp = require('../fs/mkdirp')
 
-module.exports = function (opts) {
+module.exports = opts => {
   opts = opts || {}
   const cwd = opts.cwd || process.cwd()
-  var cmd = {
+  const cmd = {
     ctx: {}
   }
-  var lockfile
+  let lockfile
   return (opts.global ? readGlobalPkg(opts.globalPath) : readPkgUp({ cwd }))
     .then(_ => { cmd.pkg = _ })
     .then(_ => updateContext())
@@ -29,7 +29,7 @@ module.exports = function (opts) {
     .then(_ => cmd)
 
   function updateContext () {
-    var root = cmd.pkg.path ? dirname(cmd.pkg.path) : cwd
+    const root = cmd.pkg.path ? dirname(cmd.pkg.path) : cwd
     cmd.ctx.root = root
     cmd.ctx.store = resolveStorePath(opts.storePath)
     lockfile = resolve(cmd.ctx.store, 'lock')
@@ -37,7 +37,7 @@ module.exports = function (opts) {
     cmd.storeJson = storeJsonController(cmd.ctx.store)
     Object.assign(cmd.ctx, cmd.storeJson.read())
     if (!opts.quiet) cmd.ctx.log = logger(opts.logger)
-    else cmd.ctx.log = function () { return function () {} }
+    else cmd.ctx.log = () => () => {}
 
     function resolveStorePath (storePath) {
       if (storePath.indexOf('~/') === 0) {

--- a/lib/api/install.js
+++ b/lib/api/install.js
@@ -56,22 +56,22 @@ function install (packagesToInstall, opts) {
   }
 
   function savePkgs (packages) {
-    var saveType = getSaveType(opts)
+    const saveType = getSaveType(opts)
     if (saveType && installType === 'named') {
-      var inputNames = Object.keys(packagesToInstall)
-      var savedPackages = packages.filter(pkg => inputNames.indexOf(pkg.name) > -1)
+      const inputNames = Object.keys(packagesToInstall)
+      const savedPackages = packages.filter(pkg => inputNames.indexOf(pkg.name) > -1)
       return save(cmd.pkg, savedPackages, saveType, opts.saveExact)
     }
   }
 
   function mainPostInstall () {
-    var scripts = cmd.pkg.pkg && cmd.pkg.pkg.scripts || {}
+    const scripts = cmd.pkg.pkg && cmd.pkg.pkg.scripts || {}
     if (scripts.postinstall) runScript('postinstall')
     if (!isProductionInstall && scripts.prepublish) runScript('prepublish')
     return
 
     function runScript (scriptName) {
-      var result = spawnSync('npm', ['run', scriptName], {
+      const result = spawnSync('npm', ['run', scriptName], {
         cwd: path.dirname(cmd.pkg.path),
         stdio: 'inherit'
       })
@@ -87,7 +87,7 @@ function mapify (pkgs) {
   if (!pkgs) return {}
   if (Array.isArray(pkgs)) {
     return pkgs.reduce((pkgsMap, pkgFullName) => {
-      var matches = /(@?[^@]+)@(.*)/.exec(pkgFullName)
+      const matches = /(@?[^@]+)@(.*)/.exec(pkgFullName)
       if (!matches) {
         pkgsMap[pkgFullName] = null
       } else {

--- a/lib/api/uninstall.js
+++ b/lib/api/uninstall.js
@@ -18,7 +18,7 @@ function uninstallCmd (pkgsToUninstall, opts) {
     .then(_ => { cmd = _ })
     .then(_ => {
       cmd.pkg.pkg.dependencies = cmd.pkg.pkg.dependencies || {}
-      var pkgFullNames = pkgsToUninstall.map(dep => cmd.ctx.dependencies[cmd.pkg.path].find(_ => _.indexOf(dep + '@') === 0))
+      const pkgFullNames = pkgsToUninstall.map(dep => cmd.ctx.dependencies[cmd.pkg.path].find(_ => _.indexOf(dep + '@') === 0))
       tryUninstall(pkgFullNames.slice())
       if (cmd.ctx.dependencies[cmd.pkg.path]) {
         pkgFullNames.forEach(dep => {
@@ -50,12 +50,12 @@ function uninstallCmd (pkgsToUninstall, opts) {
   function tryUninstall (pkgFullNames) {
     do {
       var numberOfUninstalls = 0
-      for (var i = 0; i < pkgFullNames.length;) {
+      for (let i = 0; i < pkgFullNames.length;) {
         if (canBeUninstalled(pkgFullNames[i])) {
-          var uninstalledPkg = pkgFullNames.splice(i, 1)[0]
+          const uninstalledPkg = pkgFullNames.splice(i, 1)[0]
           removeBins(uninstalledPkg)
           uninstalledPkgs.push(uninstalledPkg)
-          var deps = cmd.ctx.dependencies[uninstalledPkg] || []
+          const deps = cmd.ctx.dependencies[uninstalledPkg] || []
           delete cmd.ctx.dependencies[uninstalledPkg]
           delete cmd.ctx.dependents[uninstalledPkg]
           deps.forEach(dep => removeDependency(dep, uninstalledPkg))
@@ -77,8 +77,8 @@ function uninstallCmd (pkgsToUninstall, opts) {
   }
 
   function removeBins (uninstalledPkg) {
-    var uninstalledPkgJson = require(join(cmd.ctx.store, uninstalledPkg, '_/package.json'))
-    var bins = binify(uninstalledPkgJson)
+    const uninstalledPkgJson = require(join(cmd.ctx.store, uninstalledPkg, '_/package.json'))
+    const bins = binify(uninstalledPkgJson)
     Object.keys(bins).forEach(bin => cbRimraf.sync(join(cmd.ctx.root, 'node_modules/.bin', bin)))
   }
 

--- a/lib/binify.js
+++ b/lib/binify.js
@@ -14,7 +14,7 @@ module.exports = binify
 
 function binify (pkg) {
   if (typeof pkg.bin === 'string') {
-    var obj = {}
+    const obj = {}
     obj[pkg.name] = pkg.bin
     return obj
   }

--- a/lib/cmd/link.js
+++ b/lib/cmd/link.js
@@ -1,7 +1,7 @@
 'use strict'
 const link = require('../api/link')
 
-module.exports = function (input, opts) {
+module.exports = (input, opts) => {
   if (!input || !input.length) {
     return link.linkToGlobal(opts)
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,3 +1,4 @@
+'use strict'
 module.exports = require('rc')('pnpm', {
   concurrency: 16,
   storePath: 'node_modules/.store',

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,3 +1,4 @@
+'use strict'
 module.exports = {
   concurrency: 16,
   storePath: 'node_modules/.store',

--- a/lib/err.js
+++ b/lib/err.js
@@ -1,4 +1,5 @@
-var chalk = require('chalk')
+'use strict'
+const chalk = require('chalk')
 
 module.exports = function err (error) {
   console.error('')

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,9 +1,10 @@
-var debug = require('debug')('pnpm:fetch')
-var got = require('./got')
-var crypto = require('crypto')
-var gunzip = require('gunzip-maybe')
-var tar = require('tar-fs')
-var fs = require('fs')
+'use strict'
+const debug = require('debug')('pnpm:fetch')
+const got = require('./got')
+const crypto = require('crypto')
+const gunzip = require('gunzip-maybe')
+const tar = require('tar-fs')
+const fs = require('fs')
 
 /*
  * Fetches a tarball `tarball` and extracts it into `dir`
@@ -19,9 +20,9 @@ module.exports = function fetch (dir, dist, log) {
 
 function fetchStream (dir, tarball, shasum, log, stream) {
   return new Promise((resolve, reject) => {
-    var actualShasum = crypto.createHash('sha1')
-    var size
-    var downloaded = 0
+    const actualShasum = crypto.createHash('sha1')
+    let size
+    let downloaded = 0
 
     unpackStream(
       stream
@@ -46,7 +47,7 @@ function fetchStream (dir, tarball, shasum, log, stream) {
     }
 
     function finish () {
-      var digest = actualShasum.digest('hex')
+      const digest = actualShasum.digest('hex')
       debug('finish %s %s', shasum, tarball)
       if (shasum && digest !== shasum) {
         return reject(new Error('' + tarball + ': incorrect shasum (expected ' + shasum + ', got ' + digest + ')'))

--- a/lib/fs/expand_tilde.js
+++ b/lib/fs/expand_tilde.js
@@ -12,7 +12,7 @@ module.exports = function expandTilde (filepath) {
 }
 
 function getHomedir () {
-  var home = osHomedir()
+  const home = osHomedir()
   if (!home) throw new Error('Could not find the homedir')
   return home
 }

--- a/lib/fs/force_symlink.js
+++ b/lib/fs/force_symlink.js
@@ -1,8 +1,8 @@
 'use strict'
 
-var fs = require('fs')
-var thenify = require('thenify')
-var debug = require('debug')('pnpm:symlink')
+const fs = require('fs')
+const thenify = require('thenify')
+const debug = require('debug')('pnpm:symlink')
 
 /*
  * Creates a symlink. Re-link if a symlink already exists at the supplied
@@ -17,10 +17,10 @@ function forceSymlink (srcPath, dstPath, type, cb) {
   } catch (err) {
     if (err.code !== 'EEXIST') return cb(err)
 
-    fs.readlink(dstPath, function (err, linkString) {
+    fs.readlink(dstPath, (err, linkString) => {
       if (err || srcPath === linkString) return cb(err)
 
-      fs.unlink(dstPath, function (err) {
+      fs.unlink(dstPath, err => {
         if (err) return cb(err)
         forceSymlink(srcPath, dstPath, type, cb)
       })

--- a/lib/fs/mkdirp.js
+++ b/lib/fs/mkdirp.js
@@ -1,13 +1,14 @@
-var debug = require('debug')('pnpm:mkdirp')
+'use strict'
+const debug = require('debug')('pnpm:mkdirp')
 
 /*
  * mkdir -p as a promise.
  */
 
 module.exports = function mkdirp (path) {
-  return new Promise(function (resolve, reject) {
+  return new Promise((resolve, reject) => {
     debug(path)
-    require('mkdirp')(path, function (err) {
+    require('mkdirp')(path, err => {
       if (err) reject(err)
       else resolve(path)
     })

--- a/lib/fs/obliterate.js
+++ b/lib/fs/obliterate.js
@@ -1,5 +1,6 @@
-var rimraf = require('thenify')(require('rimraf'))
-var fs = require('mz/fs')
+'use strict'
+const rimraf = require('thenify')(require('rimraf'))
+const fs = require('mz/fs')
 
 /*
  * Removes `path`.

--- a/lib/fs/rel_symlink.js
+++ b/lib/fs/rel_symlink.js
@@ -1,11 +1,12 @@
-var symlink = require('./force_symlink')
-var dirname = require('path').dirname
-var relative = require('path').relative
-var os = require('os')
+'use strict'
+const symlink = require('./force_symlink')
+const dirname = require('path').dirname
+const relative = require('path').relative
+const os = require('os')
 
 // Always use "junctions" on Windows. Even though support for "symbolic links" was added in Vista+, users by default
 // lack permission to create them
-var symlinkType = os.platform() === 'win32' ? 'junction' : 'dir'
+const symlinkType = os.platform() === 'win32' ? 'junction' : 'dir'
 
 /*
  * Relative symlink
@@ -13,7 +14,7 @@ var symlinkType = os.platform() === 'win32' ? 'junction' : 'dir'
 
 module.exports = function relSymlink (src, dest) {
   // Junction points can't be relative
-  var rel = symlinkType !== 'junction' ? relative(dirname(dest), src) : src
+  const rel = symlinkType !== 'junction' ? relative(dirname(dest), src) : src
 
   return symlink(rel, dest, symlinkType)
 }

--- a/lib/fs/require_json.js
+++ b/lib/fs/require_json.js
@@ -1,4 +1,5 @@
-var cache = {}
+'use strict'
+const cache = {}
 
 /*
  * Works identically to require('/path/to/file.json'), but safer.

--- a/lib/fs/store_json_controller.js
+++ b/lib/fs/store_json_controller.js
@@ -1,19 +1,20 @@
-var join = require('path').join
-var writeFileSync = require('fs').writeFileSync
-var readFileSync = require('fs').readFileSync
+'use strict'
+const join = require('path').join
+const writeFileSync = require('fs').writeFileSync
+const readFileSync = require('fs').readFileSync
 
 module.exports = function storeJsonController (storePath) {
-  var storeJsonPath = join(storePath, 'store.json')
+  const storeJsonPath = join(storePath, 'store.json')
 
   return {
-    read: function () {
+    read () {
       try {
         return JSON.parse(readFileSync(storeJsonPath, 'utf8'))
       } catch (err) {
         return {}
       }
     },
-    save: function (storeJson) {
+    save (storeJson) {
       writeFileSync(storeJsonPath, JSON.stringify(storeJson, null, 2), 'utf8')
     }
   }

--- a/lib/fs/unsymlink.js
+++ b/lib/fs/unsymlink.js
@@ -1,4 +1,5 @@
-var fs = require('mz/fs')
+'use strict'
+const fs = require('mz/fs')
 
 /*
  * Removes a symlink

--- a/lib/fs/write_json.js
+++ b/lib/fs/write_json.js
@@ -1,5 +1,4 @@
-var writeFile = require('mz/fs').writeFile
+'use strict'
+const writeFile = require('mz/fs').writeFile
 
-module.exports = function (path, json) {
-  return writeFile(path, JSON.stringify(json, null, 2) + '\n', 'utf8')
-}
+module.exports = (path, json) => writeFile(path, JSON.stringify(json, null, 2) + '\n', 'utf8')

--- a/lib/get_save_type.js
+++ b/lib/get_save_type.js
@@ -1,3 +1,4 @@
+'use strict'
 module.exports = function getSaveType (opts) {
   if (opts.save || opts.global) return 'dependencies'
   if (opts.saveDev) return 'devDependencies'

--- a/lib/got.js
+++ b/lib/got.js
@@ -1,22 +1,23 @@
-var debug = require('debug')('pnpm:http')
-var throat = require('throat')
-var got = require('got')
-var HttpAgent = require('http').Agent
-var HttpsAgent = require('https').Agent
-var caw = require('caw')
-var getAuthToken = require('registry-auth-token')
+'use strict'
+const debug = require('debug')('pnpm:http')
+const throat = require('throat')
+const got = require('got')
+const HttpAgent = require('http').Agent
+const HttpsAgent = require('https').Agent
+const caw = require('caw')
+const getAuthToken = require('registry-auth-token')
 
-var cache = {}
+const cache = {}
 
 function getThroater () {
   return throat(+process.env.pnpm_config_concurrency)
 }
 
-var httpKeepaliveAgent = new HttpAgent({
+const httpKeepaliveAgent = new HttpAgent({
   keepAlive: true,
   keepAliveMsecs: 30000
 })
-var httpsKeepaliveAgent = new HttpsAgent({
+const httpsKeepaliveAgent = new HttpsAgent({
   keepAlive: true,
   keepAliveMsecs: 30000
 })
@@ -25,15 +26,15 @@ var httpsKeepaliveAgent = new HttpsAgent({
  * waits in line
  */
 
-exports.get = function (url, options) {
-  var throater = getThroater()
-  var key = JSON.stringify([ url, options ])
+exports.get = (url, options) => {
+  const throater = getThroater()
+  const key = JSON.stringify([ url, options ])
   if (!cache[key]) {
     cache[key] = new Promise(resolve => {
       throater(_ => {
         debug(url)
-        var promise = got(url, extend(url, options))
-        resolve({ promise: promise })
+        const promise = got(url, extend(url, options))
+        resolve({ promise })
         return promise
       })
     })
@@ -45,12 +46,12 @@ exports.get = function (url, options) {
  * like require('got').stream, but throated
  */
 
-exports.getStream = function (url, options) {
-  var throater = getThroater()
+exports.getStream = (url, options) => {
+  const throater = getThroater()
   return new Promise(resolve => {
     throater(_ => {
       debug(url, '[stream]')
-      var stream = got.stream(url, extend(url, options))
+      const stream = got.stream(url, extend(url, options))
       resolve(stream)
       return waiter(stream)
     })
@@ -74,7 +75,7 @@ function extend (url, options) {
   if (url.indexOf('https://') === 0) {
     options.agent = caw() || httpsKeepaliveAgent
 
-    var authToken = getAuthToken(url, {recursive: true})
+    const authToken = getAuthToken(url, {recursive: true})
     if (authToken) {
       options.headers = Object.assign({}, options.headers || {}, {
         authorization: authToken.type + ' ' + authToken.token

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,29 +1,30 @@
-var debug = require('debug')('pnpm:install')
-var npa = require('npm-package-arg')
-var getUuid = require('node-uuid')
-var fs = require('mz/fs')
-var thenify = require('thenify')
-var lock = thenify(require('lockfile').lock)
-var unlock = thenify(require('lockfile').unlock)
-var checkLock = thenify(require('lockfile').unlock)
+'use strict'
+const debug = require('debug')('pnpm:install')
+const npa = require('npm-package-arg')
+const getUuid = require('node-uuid')
+const fs = require('mz/fs')
+const thenify = require('thenify')
+const lock = thenify(require('lockfile').lock)
+const unlock = thenify(require('lockfile').unlock)
+const checkLock = thenify(require('lockfile').unlock)
 
-var join = require('path').join
-var dirname = require('path').dirname
-var basename = require('path').basename
-var abspath = require('path').resolve
+const join = require('path').join
+const dirname = require('path').dirname
+const basename = require('path').basename
+const abspath = require('path').resolve
 
-var fetch = require('./fetch')
-var resolve = require('./resolve')
+const fetch = require('./fetch')
+const resolve = require('./resolve')
 
-var mkdirp = require('./fs/mkdirp')
-var obliterate = require('./fs/obliterate')
-var requireJson = require('./fs/require_json')
-var relSymlink = require('./fs/rel_symlink')
+const mkdirp = require('./fs/mkdirp')
+const obliterate = require('./fs/obliterate')
+const requireJson = require('./fs/require_json')
+const relSymlink = require('./fs/rel_symlink')
 
-var linkBins = require('./install/link_bins')
-var linkBundledDeps = require('./install/link_bundled_deps')
-var isAvailable = require('./install/is_available')
-var postInstall = require('./install/post_install')
+const linkBins = require('./install/link_bins')
+const linkBundledDeps = require('./install/link_bundled_deps')
+const isAvailable = require('./install/is_available')
+const postInstall = require('./install/post_install')
 
 /*
  * Installs a package.
@@ -54,7 +55,7 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   if (!ctx.fetches) ctx.fetches = {}
   if (!ctx.ignoreScripts) ctx.ignoreScripts = options && options.ignoreScripts
 
-  var pkg = {
+  const pkg = {
     // Preliminary spec data
     // => { raw, name, scope, type, spec, rawSpec }
     spec: npa(pkgSpec),
@@ -79,9 +80,9 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
     data: undefined
   }
 
-  var paths = {
+  const paths = {
     // Module storage => './node_modules'
-    modules: modules,
+    modules,
 
     // Temporary destination while building
     tmp: join(ctx.store, '..', '.tmp', getUuid()),
@@ -90,7 +91,7 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
     target: undefined
   }
 
-  var log = ctx.log(pkg.spec) // function
+  const log = ctx.log(pkg.spec) // function
 
   // it might be a bundleDependency, in which case, don't bother
   return isAvailable(pkg.spec, modules)
@@ -128,7 +129,7 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   }
 
   function saveCachedResolution () {
-    var target = join(modules, pkg.spec.name)
+    const target = join(modules, pkg.spec.name)
     return fs.lstat(target)
       .then(stat => {
         if (stat.isSymbolicLink()) {
@@ -140,7 +141,7 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
       })
 
     function save (fullpath) {
-      var data = requireJson(join(fullpath, 'package.json'))
+      const data = requireJson(join(fullpath, 'package.json'))
       pkg.name = data.name
       pkg.fullname = basename(fullpath)
       pkg.version = data.version
@@ -197,8 +198,8 @@ function fetchToStore (ctx, paths, pkg, log) {
 }
 
 function buildInStore (ctx, paths, pkg, log) {
-  var installAll = require('./install_multiple')
-  var fulldata
+  const installAll = require('./install_multiple')
+  let fulldata
 
   return Promise.resolve()
     .then(_ => { fulldata = requireJson(abspath(join(paths.tmp, '_', 'package.json'))) })
@@ -238,7 +239,7 @@ function buildInStore (ctx, paths, pkg, log) {
 function installLogger (log, pkg) {
   return (stream, line) => {
     require('debug')('pnpm:post_install')('%s %s', pkg.fullname, line)
-    log(stream, { name: pkg.fullname, line: line })
+    log(stream, { name: pkg.fullname, line })
   }
 }
 
@@ -273,13 +274,13 @@ function escapeName (name) {
 
 function symlinkToModules (target, modules) {
   // TODO: uncomment to make things fail
-  var pkgData = requireJson(join(target, 'package.json'))
+  const pkgData = requireJson(join(target, 'package.json'))
   if (!pkgData.name) { throw new Error('Invalid package.json for ' + target) }
 
   // lodash -> .store/lodash@4.0.0
   // .store/foo@1.0.0/node_modules/lodash -> ../../../.store/lodash@4.0.0
   // .tmp/01234567890/node_modules/lodash -> ../../../.store/lodash@4.0.0
-  var out = join(modules, pkgData.name)
+  const out = join(modules, pkgData.name)
   return mkdirp(dirname(out))
     .then(_ => relSymlink(target, out))
 }

--- a/lib/install/is_available.js
+++ b/lib/install/is_available.js
@@ -1,6 +1,7 @@
-var semver = require('semver')
-var join = require('path').join
-var fs = require('mz/fs')
+'use strict'
+const semver = require('semver')
+const join = require('path').join
+const fs = require('mz/fs')
 
 /*
  * Check if a module exists (eg, `node_modules/node-pre-gyp`). This is the case when
@@ -14,10 +15,10 @@ var fs = require('mz/fs')
  */
 
 module.exports = function isAvailable (spec, modules) {
-  var name = spec && spec.name
+  const name = spec && spec.name
   if (!name) return Promise.resolve(false)
 
-  var packageJsonPath = join(modules, name, 'package.json')
+  const packageJsonPath = join(modules, name, 'package.json')
 
   return Promise.resolve()
     .then(_ => fs.readFile(packageJsonPath))

--- a/lib/install/link_bins.js
+++ b/lib/install/link_bins.js
@@ -1,17 +1,18 @@
-var join = require('path').join
-var basename = require('path').basename
-var relative = require('path').relative
-var semver = require('semver')
-var normalizePath = require('normalize-path')
-var relSymlink = require('../fs/rel_symlink')
-var fs = require('mz/fs')
-var mkdirp = require('../fs/mkdirp')
-var debug = require('debug')('pnpm:link_bins')
-var requireJson = require('../fs/require_json')
-var binify = require('../binify')
+'use strict'
+const join = require('path').join
+const basename = require('path').basename
+const relative = require('path').relative
+const semver = require('semver')
+const normalizePath = require('normalize-path')
+const relSymlink = require('../fs/rel_symlink')
+const fs = require('mz/fs')
+const mkdirp = require('../fs/mkdirp')
+const debug = require('debug')('pnpm:link_bins')
+const requireJson = require('../fs/require_json')
+const binify = require('../binify')
 
-var preserveSymlinks = semver.satisfies(process.version, '>=6.3.0')
-var isWindows = process.platform === 'win32'
+const preserveSymlinks = semver.satisfies(process.version, '>=6.3.0')
+const isWindows = process.platform === 'win32'
 
 module.exports = linkAllBins
 module.exports.linkPkgBins = linkPkgBins
@@ -49,26 +50,26 @@ function isScopedPkgsDir (dirPath) {
  */
 
 function linkPkgBins (modules, target) {
-  var pkg = tryRequire(join(target, 'package.json'))
+  const pkg = tryRequire(join(target, 'package.json'))
 
   if (!pkg || !pkg.bin) return
 
-  var bins = binify(pkg)
+  const bins = binify(pkg)
 
   return Promise.all(Object.keys(bins).map(bin => {
-    var actualBin = bins[bin]
-    var binDir = join(modules, '.bin')
-    var externalBinPath = join(binDir, bin)
+    const actualBin = bins[bin]
+    const binDir = join(modules, '.bin')
+    const externalBinPath = join(binDir, bin)
 
     return Promise.resolve()
       .then(_ => mkdirp(join(modules, '.bin')))
       .then(_ => {
-        var targetPath = normalizePath(join(pkg.name, actualBin))
+        const targetPath = normalizePath(join(pkg.name, actualBin))
         if (isWindows) {
           if (!preserveSymlinks) {
             return cmdShim(externalBinPath, '../' + targetPath)
           }
-          var proxyFilePath = join(binDir, bin + '.proxy')
+          const proxyFilePath = join(binDir, bin + '.proxy')
           fs.writeFileSync(proxyFilePath, 'require("../' + targetPath + '")', 'utf8')
           return cmdShim(externalBinPath, relative(binDir, proxyFilePath))
         }
@@ -93,7 +94,7 @@ function makeExecutable (filePath) {
 }
 
 function proxy (proxyPath, targetPath) {
-  var proxyContent = [
+  const proxyContent = [
     '#!/bin/sh',
     '":" //# comment; exec /usr/bin/env node --preserve-symlinks "$0" "$@"',
     "require('../" + targetPath + "')"
@@ -103,8 +104,8 @@ function proxy (proxyPath, targetPath) {
 }
 
 function cmdShim (proxyPath, targetPath) {
-  var nodeOptions = preserveSymlinks ? '--preserve-symlinks' : ''
-  var cmdContent = [
+  const nodeOptions = preserveSymlinks ? '--preserve-symlinks' : ''
+  const cmdContent = [
     '@IF EXIST "%~dp0\\node.exe" (',
     '  "%~dp0\\node.exe ' + nodeOptions + '"  "%~dp0/' + targetPath + '" %*',
     ') ELSE (',
@@ -115,7 +116,7 @@ function cmdShim (proxyPath, targetPath) {
   ].join('\n')
   fs.writeFileSync(proxyPath + '.cmd', cmdContent, 'utf8')
 
-  var shContent = [
+  const shContent = [
     '#!/bin/sh',
     'basedir=$(dirname "$(echo "$0" | sed -e \'s,\\,/,g\')")',
     '',

--- a/lib/install/link_bundled_deps.js
+++ b/lib/install/link_bundled_deps.js
@@ -1,9 +1,10 @@
-var fs = require('mz/fs')
-var join = require('path').join
-var linkBins = require('./link_bins')
+'use strict'
+const fs = require('mz/fs')
+const join = require('path').join
+const linkBins = require('./link_bins')
 
 module.exports = function linkBundledDeps (root) {
-  var nodeModules = join(root, 'node_modules')
+  const nodeModules = join(root, 'node_modules')
 
   return isDir(nodeModules, _ =>
     Promise.all(fs.readdirSync(nodeModules).map(mod =>

--- a/lib/install/link_peers.js
+++ b/lib/install/link_peers.js
@@ -1,8 +1,9 @@
-var mkdirp = require('../fs/mkdirp')
-var unsymlink = require('../fs/unsymlink')
-var relSymlink = require('../fs/rel_symlink')
-var join = require('path').join
-var semver = require('semver')
+'use strict'
+const mkdirp = require('../fs/mkdirp')
+const unsymlink = require('../fs/unsymlink')
+const relSymlink = require('../fs/rel_symlink')
+const join = require('path').join
+const semver = require('semver')
 
 /*
  * Links into `.store/node_modules`
@@ -10,12 +11,12 @@ var semver = require('semver')
 
 module.exports = function linkPeers (pkg, store, installs) {
   if (!installs) return
-  var peers = {}
-  var roots = {}
+  const peers = {}
+  const roots = {}
 
   Object.keys(installs).forEach(name => {
-    var pkgData = installs[name]
-    var realname = pkgData.name
+    const pkgData = installs[name]
+    const realname = pkgData.name
 
     if (pkgData.keypath.length === 0) {
       roots[realname] = pkgData
@@ -25,7 +26,7 @@ module.exports = function linkPeers (pkg, store, installs) {
     }
   })
 
-  var modules = join(store, 'node_modules')
+  const modules = join(store, 'node_modules')
   return mkdirp(modules)
     .then(_ => Promise.all(Object.keys(roots).map(name => {
       return unsymlink(join(modules, roots[name].name))

--- a/lib/install/post_install.js
+++ b/lib/install/post_install.js
@@ -1,16 +1,16 @@
 'use strict'
-var join = require('path').join
-var dirname = require('path').dirname
-var spawn = require('cross-spawn')
-var debug = require('debug')('pnpm:post_install')
-var delimiter = require('path').delimiter
-var byline = require('byline')
-var fs = require('mz/fs')
+const join = require('path').join
+const dirname = require('path').dirname
+const spawn = require('cross-spawn')
+const debug = require('debug')('pnpm:post_install')
+const delimiter = require('path').delimiter
+const byline = require('byline')
+const fs = require('mz/fs')
 
 module.exports = function postInstall (root_, pkg, log) {
-  var root = join(root_, '_')
+  const root = join(root_, '_')
   debug('postinstall', pkg.name + '@' + pkg.version)
-  var scripts = pkg && pkg.scripts || {}
+  const scripts = pkg && pkg.scripts || {}
   return Promise.resolve()
     .then(_ => !scripts.install && checkBindingGyp(root, log))
     .then(_ => {
@@ -52,16 +52,16 @@ function runScript (command, args, opts) {
   if (script) debug('runscript', script)
   if (!command) return Promise.resolve()
   return new Promise((resolve, reject) => {
-    var env = Object.create(process.env)
+    const env = Object.create(process.env)
     env.PATH = [
       join(opts.cwd, 'node_modules', '.bin'),
       dirname(require.resolve('../../bin/node-gyp-bin/node-gyp')),
       process.env.PATH
     ].join(delimiter)
 
-    var proc = spawn(command, args, {
+    const proc = spawn(command, args, {
       cwd: opts.cwd,
-      env: env
+      env
     })
 
     log('stderr', '$ ' + script)

--- a/lib/install_multiple.js
+++ b/lib/install_multiple.js
@@ -1,5 +1,6 @@
-var install = require('./install')
-var pkgFullName = require('./pkg_full_name')
+'use strict'
+const install = require('./install')
+const pkgFullName = require('./pkg_full_name')
 
 /*
  * Install multiple modules into `modules`.
@@ -12,44 +13,42 @@ module.exports = function installMultiple (ctx, requiredPkgsMap, optionalPkgsMap
   requiredPkgsMap = requiredPkgsMap || {}
   optionalPkgsMap = optionalPkgsMap || {}
 
-  var optionalPkgs = Object.keys(optionalPkgsMap)
+  const optionalPkgs = Object.keys(optionalPkgsMap)
     .map(pkgName => pkgMeta(pkgName, optionalPkgsMap[pkgName], true))
 
-  var requiredPkgs = Object.keys(requiredPkgsMap)
+  const requiredPkgs = Object.keys(requiredPkgsMap)
     .filter(pkgName => !optionalPkgsMap[pkgName])
     .map(pkgName => pkgMeta(pkgName, requiredPkgsMap[pkgName], false))
 
   ctx.dependents = ctx.dependents || {}
   ctx.dependencies = ctx.dependencies || {}
 
-  return Promise.all(optionalPkgs.concat(requiredPkgs).map(function (pkg) {
-    return install(ctx, pkg.fullName, modules, options)
-      .then(dependency => {
-        var depFullName = pkgFullName(dependency)
-        ctx.dependents[depFullName] = ctx.dependents[depFullName] || []
-        if (ctx.dependents[depFullName].indexOf(options.dependent) === -1) {
-          ctx.dependents[depFullName].push(options.dependent)
-        }
-        ctx.dependencies[options.dependent] = ctx.dependencies[options.dependent] || []
-        if (ctx.dependencies[options.dependent].indexOf(depFullName) === -1) {
-          ctx.dependencies[options.dependent].push(depFullName)
-        }
-        return dependency
-      })
-      .catch(err => {
-        if (pkg.optional) {
-          console.log('Skipping failed optional dependency ' + pkg.fullName + ':')
-          console.log(err.message || err)
-          return
-        }
-        throw err
-      })
-  }))
+  return Promise.all(optionalPkgs.concat(requiredPkgs).map(pkg => install(ctx, pkg.fullName, modules, options)
+    .then(dependency => {
+      const depFullName = pkgFullName(dependency)
+      ctx.dependents[depFullName] = ctx.dependents[depFullName] || []
+      if (ctx.dependents[depFullName].indexOf(options.dependent) === -1) {
+        ctx.dependents[depFullName].push(options.dependent)
+      }
+      ctx.dependencies[options.dependent] = ctx.dependencies[options.dependent] || []
+      if (ctx.dependencies[options.dependent].indexOf(depFullName) === -1) {
+        ctx.dependencies[options.dependent].push(depFullName)
+      }
+      return dependency
+    })
+    .catch(err => {
+      if (pkg.optional) {
+        console.log('Skipping failed optional dependency ' + pkg.fullName + ':')
+        console.log(err.message || err)
+        return
+      }
+      throw err
+    })))
 }
 
 function pkgMeta (name, version, optional) {
   return {
     fullName: version ? '' + name + '@' + version : name,
-    optional: optional
+    optional
   }
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,5 @@
-var supportsColor = require('supports-color')
+'use strict'
+const supportsColor = require('supports-color')
 
 module.exports = loggerType =>
   ((loggerType === 'pretty' && supportsColor)

--- a/lib/logger/pretty.js
+++ b/lib/logger/pretty.js
@@ -1,6 +1,7 @@
-var chalk = require('chalk')
+'use strict'
+const chalk = require('chalk')
 
-var observatory = require('observatory')
+const observatory = require('observatory')
 observatory.settings({ prefix: '  ', width: 74 })
 
 /*
@@ -17,11 +18,11 @@ observatory.settings({ prefix: '  ', width: 74 })
  */
 
 module.exports = function logger () {
-  var tasks = {}
+  const tasks = {}
 
   function getTask (pkg) {
     if (tasks[pkg.rawSpec]) return tasks[pkg.rawSpec]
-    var task = observatory.add(
+    const task = observatory.add(
       (pkg.name ? (pkg.name + ' ') : '') +
       chalk.gray(pkg.rawSpec || ''))
     task.status(chalk.gray('·'))
@@ -29,9 +30,9 @@ module.exports = function logger () {
     return task
   }
 
-  return function (pkg) {
-    var pkgData // package.json
-    var res // resolution
+  return pkg => {
+    let pkgData // package.json
+    let res // resolution
 
     // lazy get task
     function t () {

--- a/lib/logger/simple.js
+++ b/lib/logger/simple.js
@@ -1,12 +1,13 @@
-var chalk = require('chalk')
+'use strict'
+const chalk = require('chalk')
 
-var UPDATERS = [
+const UPDATERS = [
   'resolving', 'resolved', 'download-start', 'dependencies'
 ]
 
-var BAR_LENGTH = 20
+const BAR_LENGTH = 20
 
-var s = {
+const s = {
   gray: chalk.gray,
   green: chalk.green,
   bold: chalk.bold
@@ -17,26 +18,26 @@ var s = {
  */
 
 module.exports = function logger () {
-  var out = process.stdout
-  var progress = { done: 0, total: 0 }
-  var lastStatus
-  var done = {}
+  const out = process.stdout
+  const progress = { done: 0, total: 0 }
+  let lastStatus
+  const done = {}
 
   process.on('exit', _ => {
     out.write(reset())
   })
 
-  return function (pkg) {
-    var name = pkg.name
+  return pkg => {
+    const name = pkg.name
       ? (pkg.name + ' ' + pkg.rawSpec)
       : pkg.rawSpec
 
     update()
     progress.total += UPDATERS.length + 20
-    var left = UPDATERS.length + 20
-    var pkgData
+    let left = UPDATERS.length + 20
+    let pkgData
 
-    return function (status, args) {
+    return (status, args) => {
       if (status === 'done') progress.done += left
 
       if (~UPDATERS.indexOf(status)) {
@@ -73,9 +74,9 @@ module.exports = function logger () {
         out.write(reset() + line + '\n')
       }
 
-      var percent = progress.done / progress.total
+      const percent = progress.done / progress.total
       if (progress.total > 0 && out.isTTY) {
-        var bar = Math.round(percent * BAR_LENGTH)
+        const bar = Math.round(percent * BAR_LENGTH)
         out.write(
           reset() +
           s.bold(Math.round(percent * 100) + '%') + ' ' +

--- a/lib/pkg_full_name.js
+++ b/lib/pkg_full_name.js
@@ -1,3 +1,2 @@
-module.exports = function (pkg) {
-  return pkg.name.replace('/', '!') + '@' + pkg.version
-}
+'use strict'
+module.exports = pkg => pkg.name.replace('/', '!') + '@' + pkg.version

--- a/lib/registry_for.js
+++ b/lib/registry_for.js
@@ -1,4 +1,5 @@
-var registryUrl = require('registry-url')
+'use strict'
+const registryUrl = require('registry-url')
 
 /*
  * Returns the registry needed for a certain package.

--- a/lib/remove_deps.js
+++ b/lib/remove_deps.js
@@ -1,12 +1,13 @@
-var requireJson = require('./fs/require_json')
-var writeJson = require('./fs/write_json')
+'use strict'
+const requireJson = require('./fs/require_json')
+const writeJson = require('./fs/write_json')
 
-module.exports = function (pkg, removedPackages, saveType) {
-  var packageJson = requireJson(pkg.path)
+module.exports = (pkg, removedPackages, saveType) => {
+  const packageJson = requireJson(pkg.path)
   packageJson[saveType] = packageJson[saveType]
   if (!packageJson[saveType]) return Promise.resolve()
 
-  removedPackages.forEach(function (dependency) {
+  removedPackages.forEach(dependency => {
     delete packageJson[saveType][dependency]
   })
 

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -1,7 +1,8 @@
-var resolveNpm = require('./resolve/npm')
-var resolveTarball = require('./resolve/tarball')
-var resolveGithub = require('./resolve/github')
-var resolveLocal = require('./resolve/local')
+'use strict'
+const resolveNpm = require('./resolve/npm')
+const resolveTarball = require('./resolve/tarball')
+const resolveGithub = require('./resolve/github')
+const resolveLocal = require('./resolve/local')
 
 /**
  * Resolves a package in the NPM registry. Done as part of `install()`.

--- a/lib/resolve/github.js
+++ b/lib/resolve/github.js
@@ -1,20 +1,21 @@
-var got = require('../got')
+'use strict'
+const got = require('../got')
 
 /**
  * Resolves a 'hosted' package hosted on 'github'.
  */
 
-var PARSE_GITHUB_RE = /^github:([^\/]+)\/([^#]+)(#(.+))?$/
+const PARSE_GITHUB_RE = /^github:([^\/]+)\/([^#]+)(#(.+))?$/
 
 module.exports = function resolveGithub (pkg) {
-  var spec = parseGithubSpec(pkg)
-  return resolveRef(spec).then(function (ref) {
+  const spec = parseGithubSpec(pkg)
+  return resolveRef(spec).then(ref => {
     spec.ref = ref
-    return resolvePackageName(spec).then(function (name) {
-      var fullname = name.replace('/', '!') + ['@github', spec.owner, spec.repo, spec.ref].join('!')
+    return resolvePackageName(spec).then(name => {
+      const fullname = name.replace('/', '!') + ['@github', spec.owner, spec.repo, spec.ref].join('!')
       return {
-        name: name,
-        fullname: fullname,
+        name,
+        fullname,
         dist: {
           tarball: [
             'https://api.github.com/repos',
@@ -30,46 +31,46 @@ module.exports = function resolveGithub (pkg) {
 }
 
 function resolvePackageName (spec) {
-  var url = [
+  const url = [
     'https://api.github.com/repos',
     spec.owner,
     spec.repo,
     'contents/package.json?ref=' + spec.ref
   ].join('/')
-  return getJSON(url).then(function (body) {
-    var content = new Buffer(body.content, 'base64').toString('utf8')
-    var pkg = JSON.parse(content)
+  return getJSON(url).then(body => {
+    const content = new Buffer(body.content, 'base64').toString('utf8')
+    const pkg = JSON.parse(content)
     return pkg.name
   })
 }
 
 function resolveRef (spec) {
-  var url = [
+  const url = [
     'https://api.github.com/repos',
     spec.owner,
     spec.repo,
     'commits',
     spec.ref
   ].join('/')
-  return getJSON(url).then(function (body) { return body.sha })
+  return getJSON(url).then(body => body.sha)
 }
 
 function getJSON (url) {
   return got.get(url)
-    .then(function (res) { return res.promise })
-    .then(function (res) {
-      var body = JSON.parse(res.body)
+    .then(res => res.promise)
+    .then(res => {
+      const body = JSON.parse(res.body)
       return body
     })
 }
 
 function parseGithubSpec (pkg) {
-  var m = PARSE_GITHUB_RE.exec(pkg.hosted.shortcut)
+  const m = PARSE_GITHUB_RE.exec(pkg.hosted.shortcut)
   if (!m) {
     throw new Error('cannot parse: ' + pkg.hosted.shortcut)
   }
-  var owner = m[1]
-  var repo = m[2]
-  var ref = m[4] || 'HEAD'
-  return {owner: owner, repo: repo, ref: ref}
+  const owner = m[1]
+  const repo = m[2]
+  const ref = m[4] || 'HEAD'
+  return {owner, repo, ref}
 }

--- a/lib/resolve/local.js
+++ b/lib/resolve/local.js
@@ -1,15 +1,16 @@
-var resolve = require('path').resolve
-var spawn = require('cross-spawn')
+'use strict'
+const resolve = require('path').resolve
+const spawn = require('cross-spawn')
 
 /**
  * Resolves a package hosted on the local filesystem
  */
 
 module.exports = function resolveLocal (pkg) {
-  var dependencyPath = resolve(pkg.root, pkg.spec)
+  const dependencyPath = resolve(pkg.root, pkg.spec)
 
   return new Promise((resolve, reject) => {
-    var proc = spawn('npm', ['pack'], {
+    const proc = spawn('npm', ['pack'], {
       cwd: dependencyPath
     })
 
@@ -21,8 +22,8 @@ module.exports = function resolveLocal (pkg) {
     })
   })
   .then(_ => {
-    var localPkg = require(resolve(dependencyPath, 'package.json'))
-    var tgzFilename = localPkg.name + '-' + localPkg.version + '.tgz'
+    const localPkg = require(resolve(dependencyPath, 'package.json'))
+    const tgzFilename = localPkg.name + '-' + localPkg.version + '.tgz'
     return {
       name: localPkg.name,
       fullname: localPkg.name.replace('/', '!') + [

--- a/lib/resolve/npm.js
+++ b/lib/resolve/npm.js
@@ -1,9 +1,10 @@
-var url = require('url')
-var enc = global.encodeURIComponent
-var got = require('../got')
-var pkgFullName = require('../pkg_full_name')
-var registryUrl = require('registry-url')
-var semver = require('semver')
+'use strict'
+const url = require('url')
+const enc = global.encodeURIComponent
+const got = require('../got')
+const pkgFullName = require('../pkg_full_name')
+const registryUrl = require('registry-url')
+const semver = require('semver')
 
 /**
  * Resolves a package in the NPM registry. Done as part of `install()`.
@@ -46,24 +47,24 @@ function errify (err, pkg) {
 }
 
 function pickVersionFromRegistryDocument (pkg, dep) {
-  var versions = Object.keys(pkg.versions)
+  const versions = Object.keys(pkg.versions)
 
   if (dep.type === 'tag') {
-    var tagVersion = pkg['dist-tags'][dep.spec]
+    const tagVersion = pkg['dist-tags'][dep.spec]
     if (pkg.versions[tagVersion]) {
       return pkg.versions[tagVersion]
     }
   } else {
-    var maxVersion = semver.maxSatisfying(versions, dep.spec)
+    const maxVersion = semver.maxSatisfying(versions, dep.spec)
     if (maxVersion) {
       return pkg.versions[maxVersion]
     }
   }
 
-  var message = versions.length
+  const message = versions.length
               ? 'Versions in registry:\n' + versions.join(', ') + '\n'
               : 'No valid version found.'
-  var er = new Error('No compatible version found: ' +
+  const er = new Error('No compatible version found: ' +
                      dep.raw + '\n' + message)
   throw er
 }
@@ -76,7 +77,7 @@ function pickVersionFromRegistryDocument (pkg, dep) {
  */
 
 function toUri (pkg) {
-  var name
+  let name
 
   if (pkg.name.substr(0, 1) === '@') {
     name = '@' + enc(pkg.name.substr(1))

--- a/lib/resolve/tarball.js
+++ b/lib/resolve/tarball.js
@@ -1,5 +1,6 @@
-var basename = require('path').basename
-var crypto = require('crypto')
+'use strict'
+const basename = require('path').basename
+const crypto = require('crypto')
 
 /**
  * Resolves a 'remote' package.
@@ -15,10 +16,10 @@ var crypto = require('crypto')
  */
 
 module.exports = function resolveTarball (pkg) {
-  var name = basename(pkg.raw).replace(/(\.tgz|\.tar\.gz)$/i, '')
+  const name = basename(pkg.raw).replace(/(\.tgz|\.tar\.gz)$/i, '')
 
   return Promise.resolve({
-    name: name,
+    name,
     fullname: name + '#' + hash(pkg.raw),
     dist: {
       tarball: pkg.raw
@@ -27,7 +28,7 @@ module.exports = function resolveTarball (pkg) {
 }
 
 function hash (str) {
-  var hash = crypto.createHash('sha1')
+  const hash = crypto.createHash('sha1')
   hash.update(str)
   return hash.digest('hex')
 }

--- a/lib/runtime_error.js
+++ b/lib/runtime_error.js
@@ -1,10 +1,12 @@
+'use strict'
+
 /*
  * An error message with a `silent` flag, where the stack is supressed.
  * Used for user-friendly error messages.
  */
 
 module.exports = function runtimeError (message) {
-  var err = new Error(message)
+  const err = new Error(message)
   err.silent = true
   return err
 }

--- a/lib/save.js
+++ b/lib/save.js
@@ -1,13 +1,14 @@
-var requireJson = require('./fs/require_json')
-var writeJson = require('./fs/write_json')
-var sortedObject = require('sorted-object')
+'use strict'
+const requireJson = require('./fs/require_json')
+const writeJson = require('./fs/write_json')
+const sortedObject = require('sorted-object')
 
 module.exports = function save (pkg, installedPackages, saveType, useExactVersion) {
   // Read the latest version of package.json to avoid accidental overwriting
-  var packageJson = requireJson(pkg.path, { ignoreCache: true })
+  const packageJson = requireJson(pkg.path, { ignoreCache: true })
   packageJson[saveType] = packageJson[saveType] || {}
-  installedPackages.forEach(function (dependency) {
-    var semverCharacter = useExactVersion ? '' : '^'
+  installedPackages.forEach(dependency => {
+    const semverCharacter = useExactVersion ? '' : '^'
     packageJson[saveType][dependency.spec.name] = semverCharacter + dependency.version
   })
   packageJson[saveType] = sortedObject(packageJson[saveType])

--- a/test/index.js
+++ b/test/index.js
@@ -1,30 +1,31 @@
-var test = require('tape')
-var path = require('path')
-var join = require('path').join
-var delimiter = require('path').delimiter
-var fs = require('fs')
-var caw = require('caw')
-var isexe = require('isexe')
-var semver = require('semver')
-var spawnSync = require('cross-spawn').sync
-var thenify = require('thenify')
-var ncp = thenify(require('ncp').ncp)
+'use strict'
+const test = require('tape')
+const path = require('path')
+const join = require('path').join
+const delimiter = require('path').delimiter
+const fs = require('fs')
+const caw = require('caw')
+const isexe = require('isexe')
+const semver = require('semver')
+const spawnSync = require('cross-spawn').sync
+const thenify = require('thenify')
+const ncp = thenify(require('ncp').ncp)
 const mkdirp = require('mkdirp')
-var prepare = require('./support/prepare')
-var basicPackageJson = require('./support/simple-package.json')
-var install = require('../lib/cmd/install')
-var uninstall = require('../lib/cmd/uninstall')
-var link = require('../lib/cmd/link')
+const prepare = require('./support/prepare')
+const basicPackageJson = require('./support/simple-package.json')
+const install = require('../lib/cmd/install')
+const uninstall = require('../lib/cmd/uninstall')
+const link = require('../lib/cmd/link')
 
-var isWindows = process.platform === 'win32'
-var preserveSymlinks = semver.satisfies(process.version, '>=6.3.0')
+const isWindows = process.platform === 'win32'
+const preserveSymlinks = semver.satisfies(process.version, '>=6.3.0')
 const globalPath = join(process.cwd(), '.tmp', 'global')
 
 if (!caw() && !isWindows) {
   require('./support/sepia')
 }
 
-var stat, _
+let stat, _
 
 function isExecutable (t, filePath) {
   if (!isWindows && !preserveSymlinks) {
@@ -51,11 +52,11 @@ test('API', t => {
   t.end()
 })
 
-test('small with dependencies (rimraf)', function (t) {
+test('small with dependencies (rimraf)', t => {
   prepare()
   install(['rimraf@2.5.1'], { quiet: true })
-  .then(function () {
-    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+  .then(() => {
+    const rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
     t.ok(typeof rimraf === 'function', 'rimraf() is available')
 
     isExecutable(t, join(process.cwd(), 'node_modules', '.bin', 'rimraf'))
@@ -65,10 +66,10 @@ test('small with dependencies (rimraf)', function (t) {
   .catch(t.end)
 })
 
-test('no dependencies (lodash)', function (t) {
+test('no dependencies (lodash)', t => {
   prepare()
   install(['lodash@4.0.0'], { quiet: true })
-  .then(function () {
+  .then(() => {
     _ = require(join(process.cwd(), 'node_modules', 'lodash'))
     t.ok(typeof _ === 'function', '_ is available')
     t.ok(typeof _.clone === 'function', '_.clone is available')
@@ -76,40 +77,40 @@ test('no dependencies (lodash)', function (t) {
   }, t.end)
 })
 
-test('scoped modules without version spec (@rstacruz/tap-spec)', function (t) {
+test('scoped modules without version spec (@rstacruz/tap-spec)', t => {
   prepare()
   install(['@rstacruz/tap-spec'], { quiet: true })
-  .then(function () {
+  .then(() => {
     _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
     t.ok(typeof _ === 'function', 'tap-spec is available')
     t.end()
   }, t.end)
 })
 
-test('scoped modules with versions (@rstacruz/tap-spec@4.1.1)', function (t) {
+test('scoped modules with versions (@rstacruz/tap-spec@4.1.1)', t => {
   prepare()
   install(['@rstacruz/tap-spec@4.1.1'], { quiet: true })
-  .then(function () {
+  .then(() => {
     _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
     t.ok(typeof _ === 'function', 'tap-spec is available')
     t.end()
   }, t.end)
 })
 
-test('scoped modules (@rstacruz/tap-spec@*)', function (t) {
+test('scoped modules (@rstacruz/tap-spec@*)', t => {
   prepare()
   install(['@rstacruz/tap-spec@*'], { quiet: true })
-  .then(function () {
+  .then(() => {
     _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
     t.ok(typeof _ === 'function', 'tap-spec is available')
     t.end()
   }, t.end)
 })
 
-test('multiple scoped modules (@rstacruz/...)', function (t) {
+test('multiple scoped modules (@rstacruz/...)', t => {
   prepare()
   install(['@rstacruz/tap-spec@*', '@rstacruz/travis-encrypt@*'], { quiet: true })
-  .then(function () {
+  .then(() => {
     _ = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
     t.ok(typeof _ === 'function', 'tap-spec is available')
     _ = require(join(process.cwd(), 'node_modules', '@rstacruz/travis-encrypt'))
@@ -118,53 +119,53 @@ test('multiple scoped modules (@rstacruz/...)', function (t) {
   }, t.end)
 })
 
-test('nested scoped modules (test-pnpm-issue219 -> @zkochan/test-pnpm-issue219)', function (t) {
+test('nested scoped modules (test-pnpm-issue219 -> @zkochan/test-pnpm-issue219)', t => {
   prepare()
   install(['test-pnpm-issue219@1.0.2'], { quiet: true })
-  .then(function () {
+  .then(() => {
     _ = require(join(process.cwd(), 'node_modules', 'test-pnpm-issue219'))
     t.ok(_ === 'test-pnpm-issue219,@zkochan/test-pnpm-issue219', 'nested scoped package is available')
     t.end()
   }, t.end)
 })
 
-test('skip failing optional dependencies', function (t) {
+test('skip failing optional dependencies', t => {
   prepare()
   install(['pkg-with-failing-optional-dependency@1.0.1'], { quiet: true })
-  .then(function () {
-    var isNegative = require(join(process.cwd(), 'node_modules', 'pkg-with-failing-optional-dependency'))
+  .then(() => {
+    const isNegative = require(join(process.cwd(), 'node_modules', 'pkg-with-failing-optional-dependency'))
     t.ok(isNegative(-1), 'package with failed optional dependency has the dependencies installed correctly')
     t.end()
   }, t.end)
 })
 
-test('idempotency (rimraf)', function (t) {
+test('idempotency (rimraf)', t => {
   prepare()
   install(['rimraf@2.5.1'], { quiet: true })
-  .then(function () { return install([ 'rimraf@2.5.1' ], { quiet: true }) })
-  .then(function () {
-    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+  .then(() => install([ 'rimraf@2.5.1' ], { quiet: true }))
+  .then(() => {
+    const rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
     t.ok(typeof rimraf === 'function', 'rimraf is available')
     t.end()
   }, t.end)
 })
 
-test('overwriting (lodash@3.10.1 and @4.0.0)', function (t) {
+test('overwriting (lodash@3.10.1 and @4.0.0)', t => {
   prepare()
   install(['lodash@3.10.1'], { quiet: true })
-  .then(function () { return install([ 'lodash@4.0.0' ], { quiet: true }) })
-  .then(function () {
+  .then(() => install([ 'lodash@4.0.0' ], { quiet: true }))
+  .then(() => {
     _ = require(join(process.cwd(), 'node_modules', 'lodash', 'package.json'))
     t.ok(_.version === '4.0.0', 'lodash is 4.0.0')
     t.end()
   }, t.end)
 })
 
-test('big with dependencies and circular deps (babel-preset-2015)', function (t) {
+test('big with dependencies and circular deps (babel-preset-2015)', t => {
   prepare()
   install(['babel-preset-es2015@6.3.13'], { quiet: true })
-  .then(function () {
-    var b = require(join(process.cwd(), 'node_modules', 'babel-preset-es2015'))
+  .then(() => {
+    const b = require(join(process.cwd(), 'node_modules', 'babel-preset-es2015'))
     t.ok(typeof b === 'object', 'babel-preset-es2015 is available')
     t.end()
   }, t.end)
@@ -172,17 +173,17 @@ test('big with dependencies and circular deps (babel-preset-2015)', function (t)
 
 // NOTE: fsevents can't be installed on Windows
 if (!isWindows) {
-  test('bundleDependencies (fsevents@1.0.6)', function (t) {
+  test('bundleDependencies (fsevents@1.0.6)', t => {
     prepare()
     install(['fsevents@1.0.6'], { quiet: true })
-    .then(function () {
+    .then(() => {
       isExecutable(t, join(process.cwd(), 'node_modules', 'fsevents', 'node_modules', '.bin', 'mkdirp'))
       t.end()
     }, t.end)
   })
 }
 
-test('compiled modules (ursa@0.9.1)', function (t) {
+test('compiled modules (ursa@0.9.1)', t => {
   if (!process.env.CI || isWindows) {
     t.skip('only ran on CI')
     return t.end()
@@ -190,18 +191,18 @@ test('compiled modules (ursa@0.9.1)', function (t) {
 
   prepare()
   install(['ursa@0.9.1'], { quiet: false })
-  .then(function () {
-    var ursa = require(join(process.cwd(), 'node_modules', 'ursa'))
+  .then(() => {
+    const ursa = require(join(process.cwd(), 'node_modules', 'ursa'))
     t.ok(typeof ursa === 'object', 'ursa() is available')
     t.end()
   }, t.end)
 })
 
-test('tarballs (is-array-1.0.1.tgz)', function (t) {
+test('tarballs (is-array-1.0.1.tgz)', t => {
   prepare()
   install(['http://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz'], { quiet: true })
-  .then(function () {
-    var isArray = require(
+  .then(() => {
+    const isArray = require(
       join(process.cwd(), 'node_modules', 'is-array'))
 
     t.ok(isArray, 'isArray() is available')
@@ -214,11 +215,11 @@ test('tarballs (is-array-1.0.1.tgz)', function (t) {
   }, t.end)
 })
 
-test('local file', function (t) {
+test('local file', t => {
   prepare()
   install([local('local-pkg')], { quiet: true })
-  .then(function () {
-    var localPkg = require(
+  .then(() => {
+    const localPkg = require(
       join(process.cwd(), 'node_modules', 'local-pkg'))
 
     t.ok(localPkg, 'localPkg() is available')
@@ -229,11 +230,11 @@ test('local file', function (t) {
 
 // Skipping on CI as failing frequently there, due to environment issues
 if (!process.env.CI) {
-  test('from a github repo', function (t) {
+  test('from a github repo', t => {
     prepare()
     install(['kevva/is-negative'], { quiet: true })
-    .then(function () {
-      var localPkg = require(
+    .then(() => {
+      const localPkg = require(
         join(process.cwd(), 'node_modules', 'is-negative'))
 
       t.ok(localPkg, 'isNegative() is available')
@@ -243,15 +244,15 @@ if (!process.env.CI) {
   })
 }
 
-test('shrinkwrap compatibility', function (t) {
+test('shrinkwrap compatibility', t => {
   prepare({ dependencies: { rimraf: '*' } })
 
   install(['rimraf@2.5.1'], { quiet: true })
-  .then(function () {
-    var npm = JSON.stringify(require.resolve('npm/bin/npm-cli.js'))
-    require('child_process').exec('node ' + npm + ' shrinkwrap', function (err) {
+  .then(() => {
+    const npm = JSON.stringify(require.resolve('npm/bin/npm-cli.js'))
+    require('child_process').exec('node ' + npm + ' shrinkwrap', err => {
       if (err) return t.end(err)
-      var wrap = JSON.parse(fs.readFileSync('npm-shrinkwrap.json', 'utf-8'))
+      const wrap = JSON.parse(fs.readFileSync('npm-shrinkwrap.json', 'utf-8'))
       t.ok(wrap.dependencies.rimraf.version === '2.5.1',
         'npm shrinkwrap is successful')
       t.end()
@@ -259,74 +260,74 @@ test('shrinkwrap compatibility', function (t) {
   }, t.end)
 })
 
-test('run pre/postinstall scripts', function (t) {
+test('run pre/postinstall scripts', t => {
   prepare()
   install([local('pre-and-postinstall-scripts-example')], { quiet: true })
-  .then(function () {
-    var generatedByPreinstall = require(join(process.cwd(), 'node_modules', 'pre-and-postinstall-scripts-example/generated-by-preinstall'))
+  .then(() => {
+    const generatedByPreinstall = require(join(process.cwd(), 'node_modules', 'pre-and-postinstall-scripts-example/generated-by-preinstall'))
     t.ok(typeof generatedByPreinstall === 'function', 'generatedByPreinstall() is available')
 
-    var generatedByPostinstall = require(join(process.cwd(), 'node_modules', 'pre-and-postinstall-scripts-example/generated-by-postinstall'))
+    const generatedByPostinstall = require(join(process.cwd(), 'node_modules', 'pre-and-postinstall-scripts-example/generated-by-postinstall'))
     t.ok(typeof generatedByPostinstall === 'function', 'generatedByPostinstall() is available')
 
     t.end()
   }, t.end)
 })
 
-test('run install scripts', function (t) {
+test('run install scripts', t => {
   prepare()
   install([local('install-script-example')], { quiet: true })
-  .then(function () {
-    var generatedByInstall = require(join(process.cwd(), 'node_modules', 'install-script-example/generated-by-install'))
+  .then(() => {
+    const generatedByInstall = require(join(process.cwd(), 'node_modules', 'install-script-example/generated-by-install'))
     t.ok(typeof generatedByInstall === 'function', 'generatedByInstall() is available')
 
     t.end()
   }, t.end)
 })
 
-test('save to package.json (rimraf@2.5.1)', function (t) {
+test('save to package.json (rimraf@2.5.1)', t => {
   prepare()
   install(['rimraf@2.5.1'], { quiet: true, save: true })
-  .then(function () {
-    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+  .then(() => {
+    const rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
     t.ok(typeof rimraf === 'function', 'rimraf() is available')
 
-    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-    var dependencies = JSON.parse(pkgJson).dependencies
+    const pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    const dependencies = JSON.parse(pkgJson).dependencies
     t.deepEqual(dependencies, {rimraf: '^2.5.1'}, 'rimraf has been added to dependencies')
 
     t.end()
   }, t.end)
 })
 
-test('saveDev scoped module to package.json (@rstacruz/tap-spec)', function (t) {
+test('saveDev scoped module to package.json (@rstacruz/tap-spec)', t => {
   prepare()
   install(['@rstacruz/tap-spec'], { quiet: true, saveDev: true })
-  .then(function () {
-    var tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+  .then(() => {
+    const tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
     t.ok(typeof tapSpec === 'function', 'tapSpec() is available')
 
-    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-    var devDependencies = JSON.parse(pkgJson).devDependencies
+    const pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    const devDependencies = JSON.parse(pkgJson).devDependencies
     t.deepEqual(devDependencies, { '@rstacruz/tap-spec': '^4.1.1' }, 'tap-spec has been added to devDependencies')
 
     t.end()
   }, t.end)
 })
 
-test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & rimraf@2.5.1) (in sorted order)', function (t) {
+test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & rimraf@2.5.1) (in sorted order)', t => {
   prepare()
   install(['rimraf@2.5.1', '@rstacruz/tap-spec@latest'], { quiet: true, save: true, saveExact: true })
-  .then(function () {
-    var tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
+  .then(() => {
+    const tapSpec = require(join(process.cwd(), 'node_modules', '@rstacruz/tap-spec'))
     t.ok(typeof tapSpec === 'function', 'tapSpec() is available')
 
-    var rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
+    const rimraf = require(join(process.cwd(), 'node_modules', 'rimraf'))
     t.ok(typeof rimraf === 'function', 'rimraf() is available')
 
-    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-    var dependencies = JSON.parse(pkgJson).dependencies
-    var expectedDeps = {
+    const pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    const dependencies = JSON.parse(pkgJson).dependencies
+    const expectedDeps = {
       '@rstacruz/tap-spec': '4.1.1',
       rimraf: '2.5.1'
     }
@@ -337,10 +338,10 @@ test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & 
   }, t.end)
 })
 
-test('flattening symlinks (minimatch@3.0.0)', function (t) {
+test('flattening symlinks (minimatch@3.0.0)', t => {
   prepare()
   install(['minimatch@3.0.0'], { quiet: true })
-  .then(function () {
+  .then(() => {
     stat = fs.lstatSync(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))
     t.ok(stat.isSymbolicLink(), 'balanced-match is linked into store node_modules')
 
@@ -350,13 +351,11 @@ test('flattening symlinks (minimatch@3.0.0)', function (t) {
   }, t.end)
 })
 
-test('flattening symlinks (minimatch + balanced-match)', function (t) {
+test('flattening symlinks (minimatch + balanced-match)', t => {
   prepare()
   install(['minimatch@3.0.0'], { quiet: true })
-  .then(function () {
-    return install(['balanced-match@^0.3.0'], { quiet: true })
-  })
-  .then(function () {
+  .then(() => install(['balanced-match@^0.3.0'], { quiet: true }))
+  .then(() => {
     _ = exists(join(process.cwd(), 'node_modules', '.store', 'node_modules', 'balanced-match'))
     t.ok(!_, 'balanced-match is removed from store node_modules')
 
@@ -366,14 +365,14 @@ test('flattening symlinks (minimatch + balanced-match)', function (t) {
   }, t.end)
 })
 
-test('production install (with --production flag)', function (t) {
+test('production install (with --production flag)', t => {
   prepare(basicPackageJson)
 
   return install([], { quiet: true, production: true })
-    .then(function () {
-      var rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
+    .then(() => {
+      const rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
 
-      var tapStatErrCode
+      let tapStatErrCode
       try {
         fs.statSync(join(process.cwd(), 'node_modules', '@rstacruz'))
       } catch (err) { tapStatErrCode = err.code }
@@ -385,19 +384,19 @@ test('production install (with --production flag)', function (t) {
     }, t.end)
 })
 
-test('production install (with production NODE_ENV)', function (t) {
-  var originalNodeEnv = process.env.NODE_ENV
+test('production install (with production NODE_ENV)', t => {
+  const originalNodeEnv = process.env.NODE_ENV
   process.env.NODE_ENV = 'production'
   prepare(basicPackageJson)
 
   return install([], { quiet: true })
-    .then(function () {
+    .then(() => {
       // reset NODE_ENV
       process.env.NODE_ENV = originalNodeEnv
 
-      var rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
+      const rimrafDir = fs.statSync(join(process.cwd(), 'node_modules', 'rimraf'))
 
-      var tapStatErrCode
+      let tapStatErrCode
       try {
         fs.statSync(join(process.cwd(), 'node_modules', '@rstacruz'))
       } catch (err) { tapStatErrCode = err.code }
@@ -409,31 +408,31 @@ test('production install (with production NODE_ENV)', function (t) {
     }, t.end)
 })
 
-test('uninstall package with no dependencies', function (t) {
+test('uninstall package with no dependencies', t => {
   prepare()
   install(['is-negative@2.1.0'], { quiet: true, save: true })
   .then(_ => uninstall(['is-negative'], { save: true }))
-  .then(function () {
+  .then(() => {
     stat = exists(join(process.cwd(), 'node_modules', '.store', 'is-negative@2.1.0'))
     t.ok(!stat, 'is-negative is removed from store')
 
     stat = existsSymlink(join(process.cwd(), 'node_modules', 'is-negative'))
     t.ok(!stat, 'is-negative is removed from node_modules')
 
-    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-    var dependencies = JSON.parse(pkgJson).dependencies
-    var expectedDeps = {}
+    const pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    const dependencies = JSON.parse(pkgJson).dependencies
+    const expectedDeps = {}
     t.deepEqual(dependencies, expectedDeps, 'is-negative has been removed from dependencies')
 
     t.end()
   }, t.end)
 })
 
-test('uninstall package with dependencies and do not touch other deps', function (t) {
+test('uninstall package with dependencies and do not touch other deps', t => {
   prepare()
   install(['is-negative@2.1.0', 'camelcase-keys@3.0.0'], { quiet: true, save: true })
   .then(_ => uninstall(['camelcase-keys'], { save: true }))
-  .then(function () {
+  .then(() => {
     stat = exists(join(process.cwd(), 'node_modules', '.store', 'camelcase-keys@2.1.0'))
     t.ok(!stat, 'camelcase-keys is removed from store')
 
@@ -458,9 +457,9 @@ test('uninstall package with dependencies and do not touch other deps', function
     stat = existsSymlink(join(process.cwd(), 'node_modules', 'is-negative'))
     t.ok(stat, 'is-negative is not removed from node_modules')
 
-    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-    var dependencies = JSON.parse(pkgJson).dependencies
-    var expectedDeps = {
+    const pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    const dependencies = JSON.parse(pkgJson).dependencies
+    const expectedDeps = {
       'is-negative': '^2.1.0'
     }
     t.deepEqual(dependencies, expectedDeps, 'camelcase-keys has been removed from dependencies')
@@ -469,11 +468,11 @@ test('uninstall package with dependencies and do not touch other deps', function
   }, t.end)
 })
 
-test('uninstall package with its bin files', function (t) {
+test('uninstall package with its bin files', t => {
   prepare()
   install(['sh-hello-world@1.0.0'], { quiet: true, save: true })
   .then(_ => uninstall(['sh-hello-world'], { save: true }))
-  .then(function () {
+  .then(() => {
     // check for both a symlink and a file because in some cases the file will be a proxied not symlinked
     stat = existsSymlink(join(process.cwd(), 'node_modules', '.bin', 'sh-hello-world'))
     t.ok(!stat, 'sh-hello-world is removed from .bin')
@@ -485,11 +484,11 @@ test('uninstall package with its bin files', function (t) {
   }, t.end)
 })
 
-test('keep dependencies used by others', function (t) {
+test('keep dependencies used by others', t => {
   prepare()
   install(['hastscript@3.0.0', 'camelcase-keys@3.0.0'], { quiet: true, save: true })
   .then(_ => uninstall(['camelcase-keys'], { save: true }))
-  .then(function () {
+  .then(() => {
     stat = exists(join(process.cwd(), 'node_modules', '.store', 'camelcase-keys@2.1.0'))
     t.ok(!stat, 'camelcase-keys is removed from store')
 
@@ -505,9 +504,9 @@ test('keep dependencies used by others', function (t) {
     stat = existsSymlink(join(process.cwd(), 'node_modules', 'map-obj'))
     t.ok(!stat, 'map-obj is removed from node_modules')
 
-    var pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
-    var dependencies = JSON.parse(pkgJson).dependencies
-    var expectedDeps = {
+    const pkgJson = fs.readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    const dependencies = JSON.parse(pkgJson).dependencies
+    const expectedDeps = {
       'hastscript': '^3.0.0'
     }
     t.deepEqual(dependencies, expectedDeps, 'camelcase-keys has been removed from dependencies')
@@ -518,7 +517,7 @@ test('keep dependencies used by others', function (t) {
 
 const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-test('fail when trying to install into the same store simultaneously', function (t) {
+test('fail when trying to install into the same store simultaneously', t => {
   prepare()
   Promise.all([
     install([local('pkg-that-installs-slowly')], { quiet: true }),
@@ -530,7 +529,7 @@ test('fail when trying to install into the same store simultaneously', function 
   .then(_ => t.end(), t.end)
 })
 
-test('fail when trying to install and uninstall from the same store simultaneously', function (t) {
+test('fail when trying to install and uninstall from the same store simultaneously', t => {
   prepare()
   Promise.all([
     install([local('pkg-that-installs-slowly')], { quiet: true }),
@@ -543,11 +542,11 @@ test('fail when trying to install and uninstall from the same store simultaneous
 })
 
 if (preserveSymlinks) {
-  test('packages should find the plugins they use when symlinks are preserved', function (t) {
+  test('packages should find the plugins they use when symlinks are preserved', t => {
     prepare()
     install([local('pkg-that-uses-plugins'), local('plugin-example')], { quiet: true, save: true })
       .then(_ => {
-        var result = spawnSync('pkg-that-uses-plugins', [], {
+        const result = spawnSync('pkg-that-uses-plugins', [], {
           env: extendPathWithLocalBin()
         })
         t.equal(result.stdout.toString(), 'plugin-example\n', 'package executable have found its plugin')
@@ -557,11 +556,11 @@ if (preserveSymlinks) {
   })
 }
 
-test('run js bin file', function (t) {
+test('run js bin file', t => {
   prepare()
   install([local('hello-world-js-bin')], { quiet: true, save: true })
     .then(_ => {
-      var result = spawnSync('hello-world-js-bin', [], {
+      const result = spawnSync('hello-world-js-bin', [], {
         env: extendPathWithLocalBin()
       })
       t.equal(result.stdout.toString(), 'Hello world!\n', 'package executable printed its message')

--- a/test/packages/install-script-example/create.js
+++ b/test/packages/install-script-example/create.js
@@ -1,4 +1,4 @@
 'use strict'
-var fs = require('fs')
+const fs = require('fs')
 
 fs.writeFile(process.argv[2] + '.js', 'module.exports = function () {}\n', 'utf8')

--- a/test/packages/local-pkg/index.js
+++ b/test/packages/local-pkg/index.js
@@ -1,1 +1,1 @@
-module.exports = function () {}
+module.exports = () => {}

--- a/test/packages/pre-and-postinstall-scripts-example/create.js
+++ b/test/packages/pre-and-postinstall-scripts-example/create.js
@@ -1,4 +1,4 @@
 'use strict'
-var fs = require('fs')
+const fs = require('fs')
 
 fs.writeFile(process.argv[2] + '.js', 'module.exports = function () {}\n', 'utf8')

--- a/test/support/prepare.js
+++ b/test/support/prepare.js
@@ -1,13 +1,14 @@
-var mkdirp = require('mkdirp')
-var fs = require('fs')
-var join = require('path').join
-var root = process.cwd()
+'use strict'
+const mkdirp = require('mkdirp')
+const fs = require('fs')
+const join = require('path').join
+const root = process.cwd()
 process.env.ROOT = root
 
 module.exports = function prepare (pkg) {
-  var tmpPath = join(root, '.tmp', Math.random().toString())
+  const tmpPath = join(root, '.tmp', Math.random().toString())
   mkdirp.sync(tmpPath)
-  var json = JSON.stringify(pkg || {})
+  const json = JSON.stringify(pkg || {})
   fs.writeFileSync(join(tmpPath, 'package.json'), json, 'utf-8')
   process.chdir(tmpPath)
 }


### PR DESCRIPTION
1. I used [lebab](https://github.com/mohebifar/lebab) to transpile ES5 code to ES6.
2. Then used eslint to fix styling issues caused by transpiling.
3. Added `'use strict'` to all files so that let/const will work on Node 4