### PR TITLE
Run pnpm quietly on CI servers

### DIFF
--- a/bin/pnpm.js
+++ b/bin/pnpm.js
@@ -3,6 +3,7 @@
 const rc = require('rc')
 const camelcaseKeys = require('camelcase-keys')
 const spawnSync = require('cross-spawn').sync
+const isCI = require('is-ci')
 
 const pnpmCmds = {
   install: require('../lib/cmd/install'),
@@ -56,9 +57,10 @@ function run (argv) {
     return Promise.resolve()
   }
 
+  cli.flags.quiet = cli.flags.quiet || cli.flags.debug || isCI
+
   if (cli.flags.debug) {
     process.env.DEBUG = 'pnpm:*'
-    cli.flags.quiet = true
   }
 
   ['dryRun'].forEach(flag => {

--- a/bin/pnpm.js
+++ b/bin/pnpm.js
@@ -1,10 +1,5 @@
 #!/usr/bin/env node
 'use strict'
-if (~process.argv.indexOf('--debug')) {
-  process.env.DEBUG = 'pnpm:*'
-  process.argv.push('--quiet')
-}
-
 const rc = require('rc')
 const camelcaseKeys = require('camelcase-keys')
 const spawnSync = require('cross-spawn').sync
@@ -62,6 +57,7 @@ function run (argv) {
   }
 
   if (cli.flags.debug) {
+    process.env.DEBUG = 'pnpm:*'
     cli.flags.quiet = true
   }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "debug": "2.2.0",
     "got": "6.3.0",
     "gunzip-maybe": "1.3.1",
+    "is-ci": "1.0.9",
     "lockfile": "1.0.1",
     "meow": "3.7.0",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
The current pnpm output on CI servers is not readable. It is better to not show the logs than to show a lot of mess.