### PR TITLE
fix(post-install): prefer current node interpreter in child scripts (Fixes #296)

### DIFF
--- a/lib/install/post_install.js
+++ b/lib/install/post_install.js
@@ -56,6 +56,7 @@ function runScript (command, args, opts) {
     env.PATH = [
       join(opts.cwd, 'node_modules', '.bin'),
       dirname(require.resolve('../../bin/node-gyp-bin/node-gyp')),
+      dirname(process.execPath),
       process.env.PATH
     ].join(delimiter)
 


### PR DESCRIPTION
This is just a direct fix for my specific issue. I decided not to go down the rabbit hole of fixing the other potential incompatibilities with npm in lifecycle scripts.