### PR TITLE
fix: don't use ! as a delimiter in the store

### DIFF
--- a/docs/store-json.md
+++ b/docs/store-json.md
@@ -2,6 +2,10 @@
 
 `store.json` contains information about all the different internal/external dependencies that the packages in the store have. This is especially useful because `pnpm` allows to use shared stores.
 
+## pnpm
+
+The last compatible pnpm version that has modified the store.
+
 ## dependents
 
 A dictionary that shows what packages are dependent on each of the package from the store. The dependent packages can be other packages from the store, or packages that use the store to install their dependencies.

--- a/lib/api/init_cmd.js
+++ b/lib/api/init_cmd.js
@@ -5,6 +5,7 @@ const dirname = require('path').dirname
 const thenify = require('thenify')
 const lock = thenify(require('lockfile').lock)
 const unlock = thenify(require('lockfile').unlock)
+const semver = require('semver')
 const requireJson = require('../fs/require_json')
 const writeJson = require('../fs/write_json')
 const expandTilde = require('../fs/expand_tilde')
@@ -34,8 +35,14 @@ module.exports = opts => {
     cmd.ctx.store = resolveStorePath(opts.storePath)
     lockfile = resolve(cmd.ctx.store, 'lock')
     cmd.unlock = () => unlock(lockfile)
-    cmd.storeJson = storeJsonController(cmd.ctx.store)
-    Object.assign(cmd.ctx, cmd.storeJson.read())
+    cmd.storeJsonCtrl = storeJsonController(cmd.ctx.store)
+    const storeJson = cmd.storeJsonCtrl.read()
+
+    if (storeJson) {
+      failIfNotCompatible(storeJson.pnpm)
+    }
+
+    Object.assign(cmd.ctx, storeJson)
     if (!opts.quiet) cmd.ctx.log = logger(opts.logger)
     else cmd.ctx.log = () => () => {}
 
@@ -45,6 +52,17 @@ module.exports = opts => {
       }
       return resolve(root, storePath)
     }
+  }
+}
+
+function failIfNotCompatible (storeVersion) {
+  if (!storeVersion || !semver.satisfies(storeVersion, '>=0.28')) {
+    throw new Error(`The store structure was changed.
+      Remove it and run pnpm again.
+      More info about what was changed at: https://github.com/rstacruz/pnpm/issues/276
+      TIPS:
+        If you have a shared store, remove both the node_modules and the shared shore.
+        Otherwise just run \`rm -rf node_modules\``)
   }
 }
 

--- a/lib/api/install.js
+++ b/lib/api/install.js
@@ -2,6 +2,7 @@
 const path = require('path')
 
 const createGot = require('../network/got')
+const pnpmPkgJson = require('../../package.json')
 const initCmd = require('./init_cmd')
 const installMultiple = require('../install_multiple')
 const save = require('../save')
@@ -56,7 +57,8 @@ function install (packagesToInstall, opts) {
         Object.assign({}, opts, { dependent: cmd.pkg && cmd.pkg.path })
       )
       .then(savePkgs)
-      .then(_ => cmd.storeJson.save({
+      .then(_ => cmd.storeJsonCtrl.save({
+        pnpm: pnpmPkgJson.version,
         dependents: cmd.ctx.dependents,
         dependencies: cmd.ctx.dependencies
       }))

--- a/lib/api/uninstall.js
+++ b/lib/api/uninstall.js
@@ -30,7 +30,7 @@ function uninstallCmd (pkgsToUninstall, opts) {
       }
       return Promise.all(uninstalledPkgs.map(removePkgFromStore))
     })
-    .then(_ => cmd.storeJson.save({
+    .then(_ => cmd.storeJsonCtrl.save({
       dependents: cmd.ctx.dependents,
       dependencies: cmd.ctx.dependencies
     }))

--- a/lib/fs/store_json_controller.js
+++ b/lib/fs/store_json_controller.js
@@ -11,7 +11,7 @@ module.exports = function storeJsonController (storePath) {
       try {
         return JSON.parse(readFileSync(storeJsonPath, 'utf8'))
       } catch (err) {
-        return {}
+        return null
       }
     },
     save (storeJson) {

--- a/lib/pkg_full_name.js
+++ b/lib/pkg_full_name.js
@@ -1,2 +1,10 @@
 'use strict'
-module.exports = pkg => pkg.name.replace('/', '!') + '@' + pkg.version
+const delimiter = '+'
+
+module.exports = pkg => pkg.name.replace('/', delimiter) + '@' + escapeVersion(pkg.version)
+module.exports.delimiter = delimiter
+
+function escapeVersion (version) {
+  if (!version) return ''
+  return version.replace(/[/\\:]/g, delimiter)
+}

--- a/lib/resolve/github.js
+++ b/lib/resolve/github.js
@@ -1,4 +1,5 @@
 'use strict'
+const pkgFullName = require('../pkg_full_name')
 
 /**
  * Resolves a 'hosted' package hosted on 'github'.
@@ -12,10 +13,12 @@ module.exports = function resolveGithub (pkg, opts) {
   return resolveRef(spec).then(ref => {
     spec.ref = ref
     return resolvePackageName(spec).then(name => {
-      const fullname = name.replace('/', '!') + ['@github', spec.owner, spec.repo, spec.ref].join('!')
       return {
         name,
-        fullname,
+        fullname: pkgFullName({
+          name,
+          version: ['github', spec.owner, spec.repo, spec.ref].join(pkgFullName.delimiter)
+        }),
         dist: {
           tarball: [
             'https://api.github.com/repos',

--- a/lib/resolve/local.js
+++ b/lib/resolve/local.js
@@ -1,6 +1,7 @@
 'use strict'
 const resolve = require('path').resolve
 const spawn = require('cross-spawn')
+const pkgFullName = require('../pkg_full_name')
 
 /**
  * Resolves a package hosted on the local filesystem
@@ -32,10 +33,13 @@ module.exports = function resolveLocal (pkg) {
     const localPkg = require(resolve(dependencyPath, 'package.json'))
     return {
       name: localPkg.name,
-      fullname: localPkg.name.replace('/', '!') + [
-        '@file',
-        escapePkgPath(dependencyPath)
-      ].join('!'),
+      fullname: pkgFullName({
+        name: localPkg.name,
+        version: [
+          'file',
+          removeLeadingSlash(dependencyPath)
+        ].join(pkgFullName.delimiter)
+      }),
       dist: {
         local: true,
         tarball: resolve(dependencyPath, tgzFilename)
@@ -44,6 +48,6 @@ module.exports = function resolveLocal (pkg) {
   })
 }
 
-function escapePkgPath (pkgPath) {
-  return pkgPath.replace(/[/\\:]/g, '!').replace(/^!/, '')
+function removeLeadingSlash (pkgPath) {
+  return pkgPath.replace(/^[/\\]/, '')
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pnpm",
   "description": "A fast implementation of npm install",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "author": "Rico Sta. Cruz <rico@ricostacruz.com>",
   "bin": {
     "pnpm": "bin/pnpm.js"

--- a/test/support/prepare.js
+++ b/test/support/prepare.js
@@ -8,7 +8,9 @@ process.env.ROOT = root
 const tmpPath = join(root, '.tmp')
 mkdirp.sync(tmpPath)
 const npmrc = [
-  'store-path=./node_modules/.store'
+  'store-path=./node_modules/.store',
+  'fetch-retries=5',
+  'fetch-retry-maxtimeout=180000'
 ]
 fs.writeFileSync(join(tmpPath, '.npmrc'), npmrc, 'utf-8')
 


### PR DESCRIPTION
! can be part of a valid npm package name. Use + as a delimiter instead.

close #276

BREAKING CHANGE:

Stores created with the ! delimiter are not compatible with the new version that uses +.

Any store created by older versions of pnpm has to be removed and reinstalled.