### PR TITLE
fix(scripts): run the main and dependency pkg scripts on the same terms

### DIFF
--- a/lib/api/install.js
+++ b/lib/api/install.js
@@ -1,6 +1,5 @@
 'use strict'
 const path = require('path')
-const spawnSync = require('cross-spawn').sync
 
 const initCmd = require('./init_cmd')
 const installMultiple = require('../install_multiple')
@@ -8,6 +7,7 @@ const save = require('../save')
 const linkPeers = require('../install/link_peers')
 const runtimeError = require('../runtime_error')
 const getSaveType = require('../get_save_type')
+const runScript = require('../run_script')
 
 /*
  * Perform installation.
@@ -66,12 +66,12 @@ function install (packagesToInstall, opts) {
 
   function mainPostInstall () {
     const scripts = cmd.pkg.pkg && cmd.pkg.pkg.scripts || {}
-    if (scripts.postinstall) runScript('postinstall')
-    if (!isProductionInstall && scripts.prepublish) runScript('prepublish')
+    if (scripts.postinstall) npmRun('postinstall')
+    if (!isProductionInstall && scripts.prepublish) npmRun('prepublish')
     return
 
-    function runScript (scriptName) {
-      const result = spawnSync('npm', ['run', scriptName], {
+    function npmRun (scriptName) {
+      const result = runScript.sync('npm', ['run', scriptName], {
         cwd: path.dirname(cmd.pkg.path),
         stdio: 'inherit'
       })

--- a/lib/install/post_install.js
+++ b/lib/install/post_install.js
@@ -1,11 +1,8 @@
 'use strict'
 const join = require('path').join
-const dirname = require('path').dirname
-const spawn = require('cross-spawn')
 const debug = require('debug')('pnpm:post_install')
-const delimiter = require('path').delimiter
-const byline = require('byline')
 const fs = require('mz/fs')
+const runScript = require('../run_script')
 
 module.exports = function postInstall (root_, pkg, log) {
   const root = join(root_, '_')
@@ -37,43 +34,5 @@ function checkBindingGyp (root, log) {
   .then(_ => runScript('node-gyp', ['rebuild'], { cwd: root, log }))
   .catch(err => {
     if (err.code !== 'ENOENT') throw err
-  })
-}
-
-/*
- * Runs an npm script.
- */
-
-function runScript (command, args, opts) {
-  opts = opts || {}
-  args = args || []
-  const log = opts.log || (() => {})
-  const script = `${command}${args.length ? args.join(' ') : ''}`
-  if (script) debug('runscript', script)
-  if (!command) return Promise.resolve()
-  return new Promise((resolve, reject) => {
-    const env = Object.create(process.env)
-    env.PATH = [
-      join(opts.cwd, 'node_modules', '.bin'),
-      dirname(require.resolve('../../bin/node-gyp-bin/node-gyp')),
-      dirname(process.execPath),
-      process.env.PATH
-    ].join(delimiter)
-
-    const proc = spawn(command, args, {
-      cwd: opts.cwd,
-      env
-    })
-
-    log('stderr', '$ ' + script)
-
-    proc.on('error', reject)
-    byline(proc.stdout).on('data', line => log('stdout', line))
-    byline(proc.stderr).on('data', line => log('stderr', line))
-
-    proc.on('close', code => {
-      if (code > 0) return reject(new Error('Exit code ' + code))
-      return resolve()
-    })
   })
 }

--- a/lib/run_script.js
+++ b/lib/run_script.js
@@ -1,0 +1,49 @@
+'use strict'
+const debug = require('debug')('pnpm:run_script')
+const path = require('path')
+const byline = require('byline')
+const spawn = require('cross-spawn')
+
+module.exports = function runScript (command, args, opts) {
+  opts = opts || {}
+  args = args || []
+  const log = opts.log || (() => {})
+  const script = `${command}${args.length ? args.join(' ') : ''}`
+  if (script) debug('runscript', script)
+  if (!command) return Promise.resolve()
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, {
+      cwd: opts.cwd,
+      env: createEnv(opts.cwd)
+    })
+
+    log('stderr', '$ ' + script)
+
+    proc.on('error', reject)
+    byline(proc.stdout).on('data', line => log('stdout', line))
+    byline(proc.stderr).on('data', line => log('stderr', line))
+
+    proc.on('close', code => {
+      if (code > 0) return reject(new Error('Exit code ' + code))
+      return resolve()
+    })
+  })
+}
+
+module.exports.sync = function (command, args, opts) {
+  opts = opts || {}
+  return spawn.sync(command, args, Object.assign({}, opts, {
+    env: createEnv(opts.cwd)
+  }))
+}
+
+function createEnv (cwd) {
+  const env = Object.create(process.env)
+  env.PATH = [
+    path.join(cwd, 'node_modules', '.bin'),
+    path.dirname(require.resolve('../bin/node-gyp-bin/node-gyp')),
+    path.dirname(process.execPath),
+    process.env.PATH
+  ].join(path.delimiter)
+  return env
+}


### PR DESCRIPTION
Use the same set of environment variables when running the main package scripts and the dependencies package scripts.

close #319