### PR TITLE
Fixed usage of https via http_proxy, by passing a protocol to the caw (fixes #322)

### DIFF
--- a/lib/got.js
+++ b/lib/got.js
@@ -73,7 +73,7 @@ function waiter (stream) {
 function extend (url, options) {
   if (!options) options = {}
   if (url.indexOf('https://') === 0) {
-    options.agent = caw() || httpsKeepaliveAgent
+    options.agent = caw({ protocol: 'https' }) || httpsKeepaliveAgent
 
     const authToken = getAuthToken(url, {recursive: true})
     if (authToken) {
@@ -82,7 +82,7 @@ function extend (url, options) {
       })
     }
   } else {
-    options.agent = caw() || httpKeepaliveAgent
+    options.agent = caw({ protocol: 'http' }) || httpKeepaliveAgent
   }
   return Object.assign({}, options, {
     headers: Object.assign({}, options.headers || {}, {


### PR DESCRIPTION
Original issue: #322