### PR TITLE
Fix installing local scoped pkgs

### DIFF
--- a/lib/resolve/local.js
+++ b/lib/resolve/local.js
@@ -14,16 +14,22 @@ module.exports = function resolveLocal (pkg) {
       cwd: dependencyPath
     })
 
+    let stdout = ''
+
+    proc.stdout.on('data', data => {
+      stdout += data.toString()
+    })
+
     proc.on('error', reject)
 
     proc.on('close', code => {
       if (code > 0) return reject(new Error('Exit code ' + code))
-      return resolve()
+      let tgzFilename = stdout.trim()
+      return resolve(tgzFilename)
     })
   })
-  .then(_ => {
+  .then(tgzFilename => {
     const localPkg = require(resolve(dependencyPath, 'package.json'))
-    const tgzFilename = localPkg.name + '-' + localPkg.version + '.tgz'
     return {
       name: localPkg.name,
       fullname: localPkg.name.replace('/', '!') + [

--- a/test/index.js
+++ b/test/index.js
@@ -130,6 +130,19 @@ test('nested scoped modules (test-pnpm-issue219 -> @zkochan/test-pnpm-issue219)'
   }, t.end)
 })
 
+test('scoped modules from a directory', t => {
+  prepare()
+  install([local('local-scoped-pkg')], { quiet: true })
+  .then(() => {
+    const localPkg = require(
+      join(process.cwd(), 'node_modules', '@scope', 'local-scoped-pkg'))
+
+    t.equal(localPkg(), '@scope/local-scoped-pkg', 'localScopedPkg() is available')
+
+    t.end()
+  }, t.end)
+})
+
 test('skip failing optional dependencies', t => {
   prepare()
   install(['pkg-with-failing-optional-dependency@1.0.1'], { quiet: true })

--- a/test/packages/local-scoped-pkg/index.js
+++ b/test/packages/local-scoped-pkg/index.js
@@ -1,0 +1,1 @@
+module.exports = () => require('./package.json').name

--- a/test/packages/local-scoped-pkg/package.json
+++ b/test/packages/local-scoped-pkg/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@scope/local-scoped-pkg",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Previously name of the archive created by `npm pack` was guessed
incorrectly for scoped packages. We add special treatment for them the same
way npm does.

This approach is a little bit fragile as npm could change that schema any
time but I don't see another way of doing it at the moment.

Closes #325