### PR TITLE
fix: installation should not fail when peer has no version

### DIFF
--- a/lib/install/link_peers.js
+++ b/lib/install/link_peers.js
@@ -20,7 +20,12 @@ module.exports = function linkPeers (pkg, store, installs) {
 
     if (pkgData.keypath.length === 0) {
       roots[realname] = pkgData
-    } else if (!peers[realname] ||
+      return
+    }
+
+    // NOTE: version is not always available
+    // version is guaranteed to be there only for packages loaded from the npm registry
+    if (!peers[realname] || peers[realname].version && pkgData.version &&
       semver.gt(pkgData.version, peers[realname].version)) {
       peers[realname] = pkgData
     }

--- a/lib/resolve/github.js
+++ b/lib/resolve/github.js
@@ -12,27 +12,26 @@ module.exports = function resolveGithub (pkg, opts) {
   const spec = parseGithubSpec(pkg)
   return resolveRef(spec).then(ref => {
     spec.ref = ref
-    return resolvePackageName(spec).then(name => {
-      return {
-        name,
-        fullname: pkgFullName({
-          name,
-          version: ['github', spec.owner, spec.repo, spec.ref].join(pkgFullName.delimiter)
-        }),
-        dist: {
-          tarball: [
-            'https://api.github.com/repos',
-            spec.owner,
-            spec.repo,
-            'tarball',
-            spec.ref
-          ].join('/')
-        }
+    return resolvePackageJson(spec).then(pkg => ({
+      name: pkg.name,
+      version: pkg.version,
+      fullname: pkgFullName({
+        name: pkg.name,
+        version: ['github', spec.owner, spec.repo, spec.ref].join(pkgFullName.delimiter)
+      }),
+      dist: {
+        tarball: [
+          'https://api.github.com/repos',
+          spec.owner,
+          spec.repo,
+          'tarball',
+          spec.ref
+        ].join('/')
       }
-    })
+    }))
   })
 
-  function resolvePackageName (spec) {
+  function resolvePackageJson (spec) {
     const url = [
       'https://api.github.com/repos',
       spec.owner,
@@ -41,8 +40,7 @@ module.exports = function resolveGithub (pkg, opts) {
     ].join('/')
     return getJSON(url).then(body => {
       const content = new Buffer(body.content, 'base64').toString('utf8')
-      const pkg = JSON.parse(content)
-      return pkg.name
+      return JSON.parse(content)
     })
   }
 

--- a/lib/resolve/local.js
+++ b/lib/resolve/local.js
@@ -58,6 +58,7 @@ function resolveFolder (dependencyPath) {
     const localPkg = require(resolve(dependencyPath, 'package.json'))
     return {
       name: localPkg.name,
+      version: localPkg.version,
       fullname: pkgFullName({
         name: localPkg.name,
         version: [

--- a/test/index.js
+++ b/test/index.js
@@ -756,6 +756,13 @@ test('tarball local package', t => {
   .catch(t.end)
 })
 
+test("don't fail when peer dependency is fetched from GitHub", t => {
+  prepare()
+  install([local('test-pnpm-peer-deps')], { quiet: true })
+    .then(() => t.end())
+    .catch(t.end)
+})
+
 function extendPathWithLocalBin () {
   return {
     PATH: [

--- a/test/packages/peer-deps-in-child-pkg/package.json
+++ b/test/packages/peer-deps-in-child-pkg/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "peer-deps-in-child-pkg",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "is-negative": "2.x.x"
+  },
+  "dependencies": {
+    "is-negative": "kevva/is-negative#2.1.0"
+  }
+}

--- a/test/packages/test-pnpm-peer-deps/package.json
+++ b/test/packages/test-pnpm-peer-deps/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-pnpm-peer-deps",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "is-negative": "2.x.x"
+  },
+  "dependencies": {
+    "is-negative": "2.0.0",
+    "peer-deps-in-child-pkg": "file:../peer-deps-in-child-pkg"
+  }
+}


### PR DESCRIPTION
Expose the version when possible, but the installation shouldn't
fail even when one of the peer dependencies have no version.

close #293