### PR TITLE
feat: update notifier

### DIFF
--- a/bin/pnpm.js
+++ b/bin/pnpm.js
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 'use strict'
+const pkg = require('../package.json')
 const rc = require('rc')
 const camelcaseKeys = require('camelcase-keys')
 const spawnSync = require('cross-spawn').sync
 const isCI = require('is-ci')
+const updateNotifier = require('update-notifier')
 
 const pnpmCmds = {
   install: require('../lib/cmd/install'),
@@ -50,6 +52,8 @@ function run (argv) {
       v: 'version'
     }
   })
+
+  updateNotifier({pkg}).notify()
 
   const cmd = getCommandFullName(cli.input[0])
   if (!supportedCmds.has(cmd)) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "supports-color": "3.1.2",
     "tar-fs": "1.13.2",
     "thenify": "3.2.0",
-    "throat": "3.0.0"
+    "throat": "3.0.0",
+    "update-notifier": "1.0.2"
   },
   "devDependencies": {
     "commitizen": "^2.8.6",


### PR DESCRIPTION
Add the [update-notifier](https://github.com/yeoman/update-notifier) module used by a lot of open source projects, making it easy for users to stay up to date with latest version of pnpm.

From the `update-notifier` readme:

> Whenever you initiate the update notifier and it's not within the interval threshold, it will asynchronously check with npm in the background for available updates, then persist the result. The next time the notifier is initiated the result will be loaded into the .update property. This prevents any impact on your package startup performance. The check process is done in a unref'ed child process. This means that if you call process.exit, the check will still be performed in its own process.
