### PR TITLE
Create pnpm-debug.log file on fail

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,6 +8,10 @@ If your issue is a bug, please follow the format below:
 
 ### Code to reproduce the issue:
 
+<!--
+If there was a fatal error also include a gist of your pnpm-debug.log file.
+-->
+
 ### Expected behavior:
 
 ### Actual behavior:

--- a/bin/pnpm.js
+++ b/bin/pnpm.js
@@ -11,6 +11,7 @@ const rc = require('rc')
 const camelcaseKeys = require('camelcase-keys')
 const spawnSync = require('cross-spawn').sync
 const isCI = require('is-ci')
+require('../lib/file_logger')
 
 const pnpmCmds = {
   install: require('../lib/cmd/install'),

--- a/lib/api/init_cmd.js
+++ b/lib/api/init_cmd.js
@@ -11,7 +11,7 @@ const writeJson = require('../fs/write_json')
 const expandTilde = require('../fs/expand_tilde')
 const resolveGlobalPkgPath = require('../resolve_global_pkg_path')
 
-const logger = require('../logger')
+const initLogger = require('../logger')
 const storeJsonController = require('../fs/store_json_controller')
 const mkdirp = require('../fs/mkdirp')
 
@@ -43,8 +43,7 @@ module.exports = opts => {
     }
 
     Object.assign(cmd.ctx, storeJson)
-    if (!opts.quiet) cmd.ctx.log = logger(opts.logger)
-    else cmd.ctx.log = () => () => {}
+    if (!opts.quiet) initLogger(opts.logger)
 
     function resolveStorePath (storePath) {
       if (storePath.indexOf('~/') === 0) {

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,0 +1,18 @@
+'use strict'
+const debug = require('debug')
+const logger = require('@zkochan/logger')
+const slice = Array.prototype.slice
+
+const debugMap = {}
+
+module.exports = type => {
+  debugMap[type] = debug(type)
+  return logger.debug.bind(null, type)
+}
+
+logger.on('debug', function (ctx, level, type) {
+  if (debugMap[type]) {
+    const args = slice.call(arguments)
+    debugMap[type].apply(debugMap[type], args.slice(3))
+  }
+})

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,5 +1,5 @@
 'use strict'
-const debug = require('debug')('pnpm:fetch')
+const debug = require('./debug')('pnpm:fetch')
 const crypto = require('crypto')
 const gunzip = require('gunzip-maybe')
 const tar = require('tar-fs')

--- a/lib/file_logger.js
+++ b/lib/file_logger.js
@@ -1,0 +1,61 @@
+'use strict'
+const logger = require('@zkochan/logger')
+const fs = require('fs')
+const YAML = require('json2yaml')
+const slice = Array.prototype.slice
+
+const logFilePath = 'pnpm-debug.log'
+
+const logs = []
+
+logger.onAny(function () {
+  const args = slice.call(arguments).slice(2)
+  if (isUsefulLog.apply(null, args)) {
+    logs.push(args)
+  }
+})
+
+function isUsefulLog (level) {
+  return level !== 'progress' || arguments[2] !== 'downloading'
+}
+
+process.on('exit', code => {
+  if (code === 0) {
+    fs.unlink(logFilePath)
+    return
+  }
+
+  const prettyLogs = getPrettyLogs()
+  const yamlLogs = YAML.stringify(prettyLogs)
+  fs.writeFileSync(logFilePath, yamlLogs, 'UTF8')
+})
+
+function getPrettyLogs () {
+  const logObj = {}
+  logs.forEach((args, i) => {
+    const key = `${i} ${args[0]} ${args[1]}`
+    const rest = mergeStrings(args.slice(2).map(stringify))
+    logObj[key] = rest.length === 1 ? rest[0] : rest
+  })
+  return logObj
+}
+
+function stringify (obj) {
+  if (obj instanceof Error) return obj.toString()
+  return obj
+}
+
+function mergeStrings (arr) {
+  const mergedArr = []
+  let prevWasString = false
+  arr.forEach(el => {
+    const currentIsString = typeof el === 'string'
+    if (currentIsString && prevWasString) {
+      mergedArr[mergedArr.length - 1] += ' ' + el
+    } else {
+      mergedArr.push(el)
+    }
+    prevWasString = currentIsString
+  })
+  return mergedArr
+}

--- a/lib/fs/force_symlink.js
+++ b/lib/fs/force_symlink.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs')
 const thenify = require('thenify')
-const debug = require('debug')('pnpm:symlink')
+const debug = require('../debug')('pnpm:symlink')
 
 /*
  * Creates a symlink. Re-link if a symlink already exists at the supplied

--- a/lib/fs/mkdirp.js
+++ b/lib/fs/mkdirp.js
@@ -1,5 +1,5 @@
 'use strict'
-const debug = require('debug')('pnpm:mkdirp')
+const debug = require('../debug')('pnpm:mkdirp')
 
 /*
  * mkdir -p as a promise.

--- a/lib/install.js
+++ b/lib/install.js
@@ -3,6 +3,7 @@ const debug = require('debug')('pnpm:install')
 const npa = require('npm-package-arg')
 const fs = require('mz/fs')
 const sanitizeFilename = require('sanitize-filename')
+const logger = require('@zkochan/logger')
 
 const join = require('path').join
 const dirname = require('path').dirname
@@ -87,7 +88,7 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
     target: undefined
   }
 
-  const log = ctx.log(pkg.spec) // function
+  const log = logger.fork(pkg.spec).log.bind(null, 'progress', pkgSpec)
 
   // it might be a bundleDependency, in which case, don't bother
   return isAvailable(pkg.spec, modules)

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,5 +1,5 @@
 'use strict'
-const debug = require('debug')('pnpm:install')
+const debug = require('./debug')('pnpm:install')
 const npa = require('npm-package-arg')
 const fs = require('mz/fs')
 const sanitizeFilename = require('sanitize-filename')
@@ -242,7 +242,7 @@ function buildInStore (ctx, paths, pkg, log) {
 
 function installLogger (log, pkg) {
   return (stream, line) => {
-    require('debug')('pnpm:post_install')(`${pkg.fullname} ${line}`)
+    require('./debug')('pnpm:post_install')(`${pkg.fullname} ${line}`)
     log(stream, { name: pkg.fullname, line })
   }
 }

--- a/lib/install/post_install.js
+++ b/lib/install/post_install.js
@@ -1,6 +1,6 @@
 'use strict'
 const join = require('path').join
-const debug = require('debug')('pnpm:post_install')
+const debug = require('../debug')('pnpm:post_install')
 const fs = require('mz/fs')
 const runScript = require('../run_script')
 

--- a/lib/logger/pretty.js
+++ b/lib/logger/pretty.js
@@ -1,6 +1,6 @@
 'use strict'
 const chalk = require('chalk')
-
+const logger = require('@zkochan/logger')
 const observatory = require('observatory')
 observatory.settings({ prefix: '  ', width: 74 })
 
@@ -17,7 +17,7 @@ observatory.settings({ prefix: '  ', width: 74 })
  *     log('error', err)
  */
 
-module.exports = function logger () {
+module.exports = function () {
   const tasks = {}
 
   function getTask (pkg) {
@@ -30,9 +30,12 @@ module.exports = function logger () {
     return task
   }
 
-  return pkg => {
-    let pkgData // package.json
-    let res // resolution
+  const pkgDataMap = {}
+  const resMap = {}
+
+  logger.on('progress', (pkg, level, pkgSpec, status, args) => {
+    const pkgData = pkgDataMap[pkgSpec] // package.json
+    const res = resMap[pkgSpec] // resolution
 
     // lazy get task
     function t () {
@@ -40,54 +43,51 @@ module.exports = function logger () {
     }
 
     // the first thing it (probably) does is wait in queue to query the npm registry
-    return status
 
-    function status (status, args) {
-      if (status === 'resolving') {
-        t().status(chalk.yellow('finding ·'))
-      } else if (status === 'resolved') {
-        res = args
-      } else if (status === 'download-queued') {
-        if (res.version) {
-          t().status(chalk.gray('queued ' + res.version + ' ↓'))
-        } else {
-          t().status(chalk.gray('queued ↓'))
-        }
-      } else if (status === 'downloading' || status === 'download-start') {
-        if (res.version) {
-          t().status(chalk.yellow('downloading ' + res.version + ' ↓'))
-        } else {
-          t().status(chalk.yellow('downloading ↓'))
-        }
-        if (args && args.total && args.done < args.total) {
-          t().details('' + Math.round(args.done / args.total * 100) + '%')
-        } else {
-          t().details('')
-        }
-      } else if (status === 'done') {
-        if (pkgData) {
-          t().status(chalk.green('' + pkgData.version + ' ✓'))
-            .details('')
-        } else {
-          t().status(chalk.green('OK ✓'))
-            .details('')
-        }
-      } else if (status === 'package.json') {
-        pkgData = args
-      } else if (status === 'dependencies') {
-        t().status(chalk.gray('' + pkgData.version + ' ·'))
-          .details('')
-      } else if (status === 'error') {
-        t().status(chalk.red('ERROR ✗'))
-          .details('')
-      } else if (status === 'stdout') {
-        observatory.add(chalk.blue(args.name) + '  ' + chalk.gray(args.line))
-      } else if (status === 'stderr') {
-        observatory.add(chalk.blue(args.name) + '! ' + chalk.gray(args.line))
+    if (status === 'resolving') {
+      t().status(chalk.yellow('finding ·'))
+    } else if (status === 'resolved') {
+      resMap[pkgSpec] = args
+    } else if (status === 'download-queued') {
+      if (res.version) {
+        t().status(chalk.gray('queued ' + res.version + ' ↓'))
       } else {
-        t().status(status)
+        t().status(chalk.gray('queued ↓'))
+      }
+    } else if (status === 'downloading' || status === 'download-start') {
+      if (res.version) {
+        t().status(chalk.yellow('downloading ' + res.version + ' ↓'))
+      } else {
+        t().status(chalk.yellow('downloading ↓'))
+      }
+      if (args && args.total && args.done < args.total) {
+        t().details('' + Math.round(args.done / args.total * 100) + '%')
+      } else {
+        t().details('')
+      }
+    } else if (status === 'done') {
+      if (pkgData) {
+        t().status(chalk.green('' + pkgData.version + ' ✓'))
+          .details('')
+      } else {
+        t().status(chalk.green('OK ✓'))
           .details('')
       }
+    } else if (status === 'package.json') {
+      pkgDataMap[pkgSpec] = args
+    } else if (status === 'dependencies') {
+      t().status(chalk.gray('' + pkgData.version + ' ·'))
+        .details('')
+    } else if (status === 'error') {
+      t().status(chalk.red('ERROR ✗'))
+        .details('')
+    } else if (status === 'stdout') {
+      observatory.add(chalk.blue(args.name) + '  ' + chalk.gray(args.line))
+    } else if (status === 'stderr') {
+      observatory.add(chalk.blue(args.name) + '! ' + chalk.gray(args.line))
+    } else {
+      t().status(status)
+        .details('')
     }
-  }
+  })
 }

--- a/lib/logger/simple.js
+++ b/lib/logger/simple.js
@@ -1,5 +1,6 @@
 'use strict'
 const chalk = require('chalk')
+const logger = require('@zkochan/logger')
 
 const UPDATERS = [
   'resolving', 'resolved', 'download-start', 'dependencies'
@@ -17,7 +18,7 @@ const s = {
  * Simple percent logger
  */
 
-module.exports = function logger () {
+module.exports = function () {
   const out = process.stdout
   const progress = { done: 0, total: 0 }
   let lastStatus
@@ -27,7 +28,9 @@ module.exports = function logger () {
     out.write(reset())
   })
 
-  return pkg => {
+  const pkgDataMap = {}
+
+  logger.on('progress', (pkg, level, pkgSpec, status, args) => {
     const name = pkg.name
       ? (pkg.name + ' ' + pkg.rawSpec)
       : pkg.rawSpec
@@ -35,29 +38,27 @@ module.exports = function logger () {
     update()
     progress.total += UPDATERS.length + 20
     let left = UPDATERS.length + 20
-    let pkgData
+    const pkgData = pkgDataMap[pkgSpec]
 
-    return (status, args) => {
-      if (status === 'done') progress.done += left
+    if (status === 'done') progress.done += left
 
-      if (~UPDATERS.indexOf(status)) {
-        progress.done += 1
-        left -= 1
-      }
+    if (~UPDATERS.indexOf(status)) {
+      progress.done += 1
+      left -= 1
+    }
 
-      if (status === 'package.json') {
-        pkgData = args
-      }
+    if (status === 'package.json') {
+      pkgDataMap[pkgSpec] = args
+    }
 
-      lastStatus = name
+    lastStatus = name
 
-      if (process.env.VERBOSE) {
-        if (status !== 'downloading') update(getName() + ' ' + status)
-      } else if (status === 'done') {
-        update(getName())
-      } else {
-        update()
-      }
+    if (process.env.VERBOSE) {
+      if (status !== 'downloading') update(getName() + ' ' + status)
+    } else if (status === 'done') {
+      update(getName())
+    } else {
+      update()
     }
 
     function getName () {
@@ -85,7 +86,7 @@ module.exports = function logger () {
           s.gray(lastStatus.substr(0, 40))) + ' '
       }
     }
-  }
+  })
 
   function reset () {
     return out.isTTY

--- a/lib/network/got.js
+++ b/lib/network/got.js
@@ -1,5 +1,5 @@
 'use strict'
-const debug = require('debug')('pnpm:http')
+const debug = require('../debug')('pnpm:http')
 const throat = require('throat')
 const got = require('got')
 const HttpAgent = require('http').Agent

--- a/lib/run_script.js
+++ b/lib/run_script.js
@@ -1,5 +1,5 @@
 'use strict'
-const debug = require('debug')('pnpm:run_script')
+const debug = require('./debug')('pnpm:run_script')
 const path = require('path')
 const byline = require('byline')
 const spawn = require('cross-spawn')

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cached_node_modules/"
   ],
   "dependencies": {
+    "@zkochan/logger": "0.1.0",
     "byline": "5.0.0",
     "camelcase-keys": "3.0.0",
     "caw": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gunzip-maybe": "1.3.1",
     "is-ci": "1.0.9",
     "is-retry-allowed": "1.1.0",
+    "json2yaml": "1.1.0",
     "lockfile": "1.0.1",
     "meow": "3.7.0",
     "mkdirp": "0.5.1",

--- a/test/index.js
+++ b/test/index.js
@@ -768,6 +768,18 @@ test("don't fail when peer dependency is fetched from GitHub", t => {
     .catch(t.end)
 })
 
+test('create a pnpm-debug.log file when the command fails', t => {
+  prepare()
+
+  const result = spawnSync('node', [pnpmBin, 'install', '@zkochan/i-do-not-exist'])
+
+  t.equal(result.status, 1, 'install failed')
+
+  exists('pnpm-debug.log')
+
+  t.end()
+})
+
 function extendPathWithLocalBin () {
   return {
     PATH: [


### PR DESCRIPTION
I created a custom logger for this feature (please review it as well [@zkochan/logger](https://github.com/zkochan/logger)). If it is fine, I'll transfer it to the pnpm organization.

The main idea is to use a logger which emits events with the logging info. The file logger records all the different logging levels. The progress logger listens only the `progress` type.

Also I substituted the debug usages with @zkochan/logger usages. But I did not remove debug, it listens now for debug logging events.

Example output: https://gist.github.com/zkochan/272e4c60eb3248373c63af9bc2db8924