### PR TITLE
Run post install scripts after all dependencies were installed

### DIFF
--- a/lib/api/install.js
+++ b/lib/api/install.js
@@ -13,6 +13,7 @@ const runtimeError = require('../runtime_error')
 const getSaveType = require('../get_save_type')
 const runScript = require('../run_script')
 const postInstall = require('../install/post_install')
+const linkBins = require('../install/link_bins')
 
 /*
  * Perform installation.
@@ -36,8 +37,8 @@ function install (packagesToInstall, opts) {
     .then(_ => {
       if (cmd.ctx.ignoreScripts || !cmd.ctx.piq || !cmd.ctx.piq.length) return
       return seq(
-        cmd.ctx.piq.map(pkg => () =>
-          postInstall(pkg.path, installLogger(pkg.pkgFullname))
+        cmd.ctx.piq.map(pkg => () => linkBins(path.join(pkg.path, '_', 'node_modules'))
+            .then(() => postInstall(pkg.path, installLogger(pkg.pkgFullname)))
             .catch(err => {
               if (cmd.ctx.installs[pkg.pkgFullname].optional) {
                 console.log('Skipping failed optional dependency ' + pkg.pkgFullname + ':')
@@ -49,6 +50,7 @@ function install (packagesToInstall, opts) {
         )
       )
     })
+    .then(_ => linkBins(path.join(cmd.ctx.root, 'node_modules')))
     .then(_ => mainPostInstall())
     .then(_ => cmd.unlock())
     .catch(err => {

--- a/lib/api/install.js
+++ b/lib/api/install.js
@@ -1,5 +1,7 @@
 'use strict'
 const path = require('path')
+const seq = require('promisequence')
+const chalk = require('chalk')
 
 const createGot = require('../network/got')
 const pnpmPkgJson = require('../../package.json')
@@ -10,6 +12,7 @@ const linkPeers = require('../install/link_peers')
 const runtimeError = require('../runtime_error')
 const getSaveType = require('../get_save_type')
 const runScript = require('../run_script')
+const postInstall = require('../install/post_install')
 
 /*
  * Perform installation.
@@ -29,6 +32,23 @@ function install (packagesToInstall, opts) {
     .then(_ => { cmd = _ })
     .then(_ => install())
     .then(_ => linkPeers(cmd.pkg, cmd.ctx.store, cmd.ctx.installs))
+    // postinstall hooks
+    .then(_ => {
+      if (cmd.ctx.ignoreScripts || !cmd.ctx.piq || !cmd.ctx.piq.length) return
+      return seq(
+        cmd.ctx.piq.map(pkg => () =>
+          postInstall(pkg.path, installLogger(pkg.pkgFullname))
+            .catch(err => {
+              if (cmd.ctx.installs[pkg.pkgFullname].optional) {
+                console.log('Skipping failed optional dependency ' + pkg.pkgFullname + ':')
+                console.log(err.message || err)
+                return
+              }
+              throw err
+            })
+        )
+      )
+    })
     .then(_ => mainPostInstall())
     .then(_ => cmd.unlock())
     .catch(err => {
@@ -90,6 +110,18 @@ function install (packagesToInstall, opts) {
         return
       }
     }
+  }
+}
+
+function installLogger (pkgFullname) {
+  return (stream, line) => {
+    require('debug')('pnpm:post_install')(`${pkgFullname} ${line}`)
+
+    if (stream === 'stderr') {
+      console.log(chalk.blue(pkgFullname) + '! ' + chalk.gray(line))
+      return
+    }
+    console.log(chalk.blue(pkgFullname) + '  ' + chalk.gray(line))
   }
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -18,7 +18,6 @@ const obliterate = require('./fs/obliterate')
 const requireJson = require('./fs/require_json')
 const relSymlink = require('./fs/rel_symlink')
 
-const linkBins = require('./install/link_bins')
 const linkBundledDeps = require('./install/link_bundled_deps')
 const isAvailable = require('./install/is_available')
 
@@ -102,8 +101,6 @@ module.exports = function install (ctx, pkgMeta, modules, options) {
         .then(_ => buildToStoreCached(ctx, paths, pkg, log))
         .then(_ => mkdirp(paths.modules))
         .then(_ => symlinkToModules(join(paths.target, '_'), paths.modules))
-        // link node_modules/.bin
-        .then(_ => linkBins(paths.modules))
         .then(_ => log('package.json', requireJson(join(paths.target, '_', 'package.json')))))
     // done
     .then(_ => {

--- a/lib/install.js
+++ b/lib/install.js
@@ -21,7 +21,6 @@ const relSymlink = require('./fs/rel_symlink')
 const linkBins = require('./install/link_bins')
 const linkBundledDeps = require('./install/link_bundled_deps')
 const isAvailable = require('./install/is_available')
-const postInstall = require('./install/post_install')
 
 /*
  * Installs a package.
@@ -46,8 +45,8 @@ const postInstall = require('./install/post_install')
  * - symlink bins
  */
 
-module.exports = function install (ctx, pkgSpec, modules, options) {
-  debug('installing ' + pkgSpec)
+module.exports = function install (ctx, pkgMeta, modules, options) {
+  debug('installing ' + pkgMeta.rawSpec)
   if (!ctx.builds) ctx.builds = {}
   if (!ctx.fetches) ctx.fetches = {}
   if (!ctx.ignoreScripts) ctx.ignoreScripts = options && options.ignoreScripts
@@ -55,7 +54,9 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
   const pkg = {
     // Preliminary spec data
     // => { raw, name, scope, type, spec, rawSpec }
-    spec: npa(pkgSpec),
+    spec: npa(pkgMeta.rawSpec),
+
+    optional: pkgMeta.optional || options.optional,
 
     // Dependency path to the current package. Not actually needed anmyore
     // outside getting its length
@@ -82,13 +83,13 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
     modules,
 
     // Temporary destination while building
-    tmp: join(ctx.store, '..', '.tmp', toUniqueDirname(pkgSpec)),
+    tmp: join(ctx.store, '..', '.tmp', toUniqueDirname(pkgMeta.rawSpec)),
 
     // Final destination => store + '/lodash@4.0.0'
     target: undefined
   }
 
-  const log = logger.fork(pkg.spec).log.bind(null, 'progress', pkgSpec)
+  const log = logger.fork(pkg.spec).log.bind(null, 'progress', pkgMeta.rawSpec)
 
   // it might be a bundleDependency, in which case, don't bother
   return isAvailable(pkg.spec, modules)
@@ -107,7 +108,11 @@ module.exports = function install (ctx, pkgSpec, modules, options) {
     // done
     .then(_ => {
       if (!ctx.installs) ctx.installs = {}
-      ctx.installs[pkg.fullname] = pkg
+      if (!ctx.installs[pkg.fullname]) {
+        ctx.installs[pkg.fullname] = pkg
+        return
+      }
+      ctx.installs[pkg.fullname].optional = ctx.installs[pkg.fullname].optional && pkg.optional
     })
     .then(_ => log('done'))
     .then(_ => pkg)
@@ -219,15 +224,13 @@ function buildInStore (ctx, paths, pkg, log) {
       {
         keypath: pkg.keypath.concat([ pkg.fullname ]),
         dependent: pkg.fullname,
-        parentRoot: pkg.root
+        parentRoot: pkg.root,
+        optional: pkg.optional
       }))
 
     // symlink itself; . -> node_modules/lodash@4.0.0
     // this way it can require itself
     .then(_ => symlinkSelf(paths.tmp, fulldata, pkg.keypath.length))
-
-    // postinstall hooks
-    .then(_ => !ctx.ignoreScripts && postInstall(paths.tmp, fulldata, installLogger(log, pkg)))
 
     // move to .store/lodash@4.0.0; remove the stub done earlier
     .then(_ => fs.unlink(join(paths.tmp, '.pnpm_inprogress')))
@@ -235,16 +238,14 @@ function buildInStore (ctx, paths, pkg, log) {
     // on this package will not get called inbetween `unlink` and `rename`
     // the easiest way to achieve this is to make them synchronous
     .then(_ => {
+      ctx.piq = ctx.piq || []
+      ctx.piq.push({
+        path: paths.target,
+        pkgFullname: pkg.fullname
+      })
       fs.unlinkSync(paths.target)
       fs.renameSync(paths.tmp, paths.target)
     })
-}
-
-function installLogger (log, pkg) {
-  return (stream, line) => {
-    require('./debug')('pnpm:post_install')(`${pkg.fullname} ${line}`)
-    log(stream, { name: pkg.fullname, line })
-  }
 }
 
 /*

--- a/lib/install/link_bins.js
+++ b/lib/install/link_bins.js
@@ -25,7 +25,16 @@ function linkAllBins (modules) {
 }
 
 function getDirectories (srcPath) {
-  return fs.readdirSync(srcPath)
+  let dirs
+  try {
+    dirs = fs.readdirSync(srcPath)
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
+    dirs = []
+  }
+  return dirs
     .map(relativePath => join(srcPath, relativePath))
     .filter(absolutePath => fs.statSync(absolutePath).isDirectory())
 }

--- a/lib/install/post_install.js
+++ b/lib/install/post_install.js
@@ -4,8 +4,9 @@ const debug = require('../debug')('pnpm:post_install')
 const fs = require('mz/fs')
 const runScript = require('../run_script')
 
-module.exports = function postInstall (root_, pkg, log) {
+module.exports = function postInstall (root_, log) {
   const root = join(root_, '_')
+  const pkg = require(join(root, 'package.json'))
   debug('postinstall', pkg.name + '@' + pkg.version)
   const scripts = pkg && pkg.scripts || {}
   return Promise.resolve()

--- a/lib/install_multiple.js
+++ b/lib/install_multiple.js
@@ -23,7 +23,7 @@ module.exports = function installMultiple (ctx, requiredPkgsMap, optionalPkgsMap
   ctx.dependents = ctx.dependents || {}
   ctx.dependencies = ctx.dependencies || {}
 
-  return Promise.all(optionalPkgs.concat(requiredPkgs).map(pkg => install(ctx, pkg.fullName, modules, options)
+  return Promise.all(optionalPkgs.concat(requiredPkgs).map(pkg => install(ctx, pkg, modules, options)
     .then(dependency => {
       const depFullName = pkgFullName(dependency)
       ctx.dependents[depFullName] = ctx.dependents[depFullName] || []
@@ -38,7 +38,7 @@ module.exports = function installMultiple (ctx, requiredPkgsMap, optionalPkgsMap
     })
     .catch(err => {
       if (pkg.optional) {
-        console.log('Skipping failed optional dependency ' + pkg.fullName + ':')
+        console.log('Skipping failed optional dependency ' + pkg.rawSpec + ':')
         console.log(err.message || err)
         return
       }
@@ -48,7 +48,7 @@ module.exports = function installMultiple (ctx, requiredPkgsMap, optionalPkgsMap
 
 function pkgMeta (name, version, optional) {
   return {
-    fullName: version ? '' + name + '@' + version : name,
+    rawSpec: version ? '' + name + '@' + version : name,
     optional
   }
 }

--- a/lib/logger/pretty.js
+++ b/lib/logger/pretty.js
@@ -81,10 +81,6 @@ module.exports = function () {
     } else if (status === 'error') {
       t().status(chalk.red('ERROR ✗'))
         .details('')
-    } else if (status === 'stdout') {
-      observatory.add(chalk.blue(args.name) + '  ' + chalk.gray(args.line))
-    } else if (status === 'stderr') {
-      observatory.add(chalk.blue(args.name) + '! ' + chalk.gray(args.line))
     } else {
       t().status(status)
         .details('')

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "npm-package-arg": "4.2.0",
     "observatory": "1.0.0",
     "os-homedir": "1.0.1",
+    "promisequence": "1.1.6",
     "rc": "1.1.6",
     "read-pkg-up": "1.0.1",
     "registry-auth-token": "3.0.1",


### PR DESCRIPTION
pnpm currently runs the post install scripts of dependencies immediately once their resources were downloaded and does that asynchronously.

npm runs all the post install scripts once all the resources were downloaded and does that sequentially.

This changes makes pnpm run the scripts similarly to how npm runs them

Solves #337 