### PR TITLE
fix(lifecycle): use the correct PATH env variable on Windows

### DIFF
--- a/src/run_script.ts
+++ b/src/run_script.ts
@@ -4,6 +4,17 @@ import path = require('path')
 import byline = require('byline')
 import spawn = require('cross-spawn')
 
+let PATH: string
+// windows calls it's path 'Path' usually, but this is not guaranteed.
+if (process.platform === 'win32') {
+  PATH = 'Path'
+  Object.keys(process.env).forEach(e => {
+    if (e.match(/^PATH$/i)) {
+      PATH = e
+    }
+  })
+}
+
 export type RunScriptOptions = {
   cwd: string,
   log: Function
@@ -49,11 +60,11 @@ export function sync (command: string, args: string[], opts: RunSyncScriptOption
 
 function createEnv (cwd: string) {
   const env = Object.create(process.env)
-  env.PATH = [
+  env[PATH] = [
     path.join(cwd, 'node_modules', '.bin'),
     path.dirname(require.resolve('../bin/node-gyp-bin/node-gyp')),
     path.dirname(process.execPath),
-    process.env.PATH
+    process.env[PATH]
   ].join(path.delimiter)
   return env
 }


### PR DESCRIPTION
Sometimes PATH env variable is called Path on Windows

The solution is a copy/paste [from npm](https://github.com/npm/npm/blob/8fa75cd0313e3cea8459f89b79208461e54b033b/lib/utils/lifecycle.js#L20-L28)