### PR TITLE
fix(uninstall): dependencies from all sources can be deleted

### DIFF
--- a/docs/store-json.md
+++ b/docs/store-json.md
@@ -28,18 +28,18 @@ For example, `pnpm` has a dependency on `npm` and `semver`. But `semver` is also
 
 ## dependencies
 
-A dictionary that is pretty match the opposite of `dependents`. The `store.json` from the previous example would contain the following `dependencies` property:
+A dictionary that is the opposite of `dependents`. However, it contains not just a list of dependency names but a map of the dependencies to their exact resolved ID.
 
 ```json
 {
   "dependencies": {
-    "/home/john_smith/src/pnpm/package.json": [
-      "semver@5.3.0",
-      "npm@3.10.2"
-    ],
-    "npm@3.10.2": [
-      "semver@5.3.0"
-    ]
+    "/home/john_smith/src/pnpm/package.json": {
+      "semver": "semver@5.3.0",
+      "npm": "npm@3.10.2"
+    },
+    "npm@3.10.2": {
+      "semver": "semver@5.3.0"
+    }
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pnpm",
   "description": "A fast implementation of npm install",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "author": "Rico Sta. Cruz <rico@ricostacruz.com>",
   "bin": {
     "pnpm": "lib/bin/pnpm.js"

--- a/src/api/initCmd.ts
+++ b/src/api/initCmd.ts
@@ -116,6 +116,12 @@ function failIfNotCompatible (storeVersion: string) {
     `)
     throw new Error(msg)
   }
+  if (!semver.satisfies(storeVersion, '>=0.37')) {
+    const msg = structureChangeMsg(stripIndent`
+      The structure of store.json/dependencies was changed to map dependencies to their fullnames
+    `)
+    throw new Error(msg)
+  }
 }
 
 function structureChangeMsg (moreInfo: string): string {

--- a/src/fs/storeJsonController.ts
+++ b/src/fs/storeJsonController.ts
@@ -1,13 +1,19 @@
 import path = require('path')
 import fs = require('fs')
 
-export type StoreDependencies = {
+export type StoreDependents = {
   [name: string]: string[]
+}
+
+export type StoreDependencies = {
+  [name: string]: {
+    [name: string]: string
+  }
 }
 
 export type StoreJson = {
   pnpm: string,
-  dependents: StoreDependencies,
+  dependents: StoreDependents,
   dependencies: StoreDependencies
 }
 

--- a/src/installMultiple.ts
+++ b/src/installMultiple.ts
@@ -1,5 +1,7 @@
 import install, {InstalledPackage, InstallationOptions} from './install'
 import {InstallContext} from './api/install'
+import createDebug from './debug'
+const debug = createDebug('pnpm:install_multiple')
 
 export type Dependencies = {
   [name: string]: string
@@ -38,10 +40,15 @@ export default function installMultiple (ctx: InstallContext, requiredPkgsMap: D
       if (ctx.storeJson.dependents[depFullName].indexOf(options.dependent) === -1) {
         ctx.storeJson.dependents[depFullName].push(options.dependent)
       }
-      ctx.storeJson.dependencies[options.dependent] = ctx.storeJson.dependencies[options.dependent] || []
-      if (ctx.storeJson.dependencies[options.dependent].indexOf(depFullName) === -1) {
-        ctx.storeJson.dependencies[options.dependent].push(depFullName)
+      ctx.storeJson.dependencies[options.dependent] = ctx.storeJson.dependencies[options.dependent] || {}
+
+      // this shouldn't normally happen
+      if (ctx.storeJson.dependencies[options.dependent][dependency.pkg.name]) {
+        const prevFullname = ctx.storeJson.dependencies[options.dependent][dependency.pkg.name]
+        debug(`rewriting dependency of ${options.dependent} from ${prevFullname} to ${depFullName}`)
       }
+
+      ctx.storeJson.dependencies[options.dependent][dependency.pkg.name] = depFullName
       return dependency
     } catch (err) {
       if (pkg.optional) {

--- a/test/uninstall.ts
+++ b/test/uninstall.ts
@@ -34,6 +34,40 @@ test('uninstall package with no dependencies', async function (t) {
   t.deepEqual(dependencies, expectedDeps, 'is-negative has been removed from dependencies')
 })
 
+test('uninstall scoped package', async function (t) {
+  prepare()
+  await install(['@zkochan/logger@0.1.0'], { quiet: true, save: true })
+  await uninstall(['@zkochan/logger'], { save: true })
+
+  let stat = exists(path.join(process.cwd(), 'node_modules', '.store', '@zkochan+logger@0.1.0'))
+  t.ok(!stat, '@zkochan/logger is removed from store')
+
+  stat = existsSymlink(path.join(process.cwd(), 'node_modules', '@zkochan/logger'))
+  t.ok(!stat, '@zkochan/logger is removed from node_modules')
+
+  const pkgJson = fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
+  const dependencies = JSON.parse(pkgJson).dependencies
+  const expectedDeps = {}
+  t.deepEqual(dependencies, expectedDeps, '@zkochan/logger has been removed from dependencies')
+})
+
+test('uninstall tarball dependency', async function (t) {
+  prepare()
+  await install(['http://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz'], { quiet: true, save: true })
+  await uninstall(['is-array'], { save: true })
+
+  let stat = exists(path.join(process.cwd(), 'node_modules', '.store', 'is-array-1.0.1#a83102a9c117983e6ff4d85311fb322231abe3d6'))
+  t.ok(!stat, 'is-array is removed from store')
+
+  stat = existsSymlink(path.join(process.cwd(), 'node_modules', 'is-array'))
+  t.ok(!stat, 'is-array is removed from node_modules')
+
+  const pkgJson = fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
+  const dependencies = JSON.parse(pkgJson).dependencies
+  const expectedDeps = {}
+  t.deepEqual(dependencies, expectedDeps, 'is-array has been removed from dependencies')
+})
+
 test('uninstall package with dependencies and do not touch other deps', async function (t) {
   prepare()
   await install(['is-negative@2.1.0', 'camelcase-keys@3.0.0'], { quiet: true, save: true })


### PR DESCRIPTION
pnpm uninstall could not always link the dependency name to the dependency ID (used in the store). To solve this issue, a dependency name to ID map is added to the dependencies section of `store.json`.

BREAKING CHANGE:

The structure of the `store.json` has been changed.

Previously the dependencies property contained just a list of dependency IDs. E.g.:

```json
{
  "dependencies": {
    "math": [
      "sum@1.0.0",
      "@zkochan+max@2.1.0"
    ]
  }
}
```

With this structure it was hard to link the dependencies to their IDs. The new structure uses a map which links the dependency to its ID:

```json
{
  "dependencies": {
    "map": {
      "sum": "sum@1.0.0",
      "@zkochan/max": "@zkochan+max@2.1.0"
    }
  }
}
```

Unfortunately the stores created by older version of pnpm are not usable after this breaking change. They have to be removed before using the new version of pnpm.