### PR TITLE
fix: peers linking on Node.js >= 6.3.0

### DIFF
--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -10,7 +10,7 @@ import createGot from '../network/got'
 import getContext, {PnpmContext} from './getContext'
 import installMultiple from '../installMultiple'
 import save from '../save'
-import linkPeers from '../install/linkPeers'
+import linkPeers, {linkPeersWhenSymlinksPreserved} from '../install/linkPeers'
 import runtimeError from '../runtimeError'
 import getSaveType from '../getSaveType'
 import {sync as runScriptSync} from '../runScript'
@@ -26,6 +26,7 @@ import {save as saveModules} from '../fs/modulesController'
 import {tryUninstall, removePkgFromStore} from './uninstall'
 import flattenDependencies from '../install/flattenDependencies'
 import mkdirp from '../fs/mkdirp'
+import {preserveSymlinks} from '../env'
 
 export type PackageInstallationResult = {
   path: string,
@@ -126,7 +127,12 @@ async function installInContext (installType: string, packagesToInstall: Depende
     await saveModules(path.join(ctx.root, 'node_modules'), {storePath: ctx.storePath})
   }
 
-  await linkPeers(ctx.storePath, installCtx.installs)
+  if (!preserveSymlinks) {
+    await linkPeers(ctx.storePath, installCtx.installs)
+  } else {
+    await linkPeersWhenSymlinksPreserved(ctx.storePath, installCtx.installs)
+  }
+
   // postinstall hooks
   if (!(opts.ignoreScripts || !installCtx.piq || !installCtx.piq.length)) {
     await seq(

--- a/src/fs/storeController.ts
+++ b/src/fs/storeController.ts
@@ -4,6 +4,7 @@ import {
   read as readYaml,
   write as writeYaml
 } from './yamlfs'
+import {preserveSymlinks} from '../env'
 
 const storeFileName = 'store.yaml'
 
@@ -23,6 +24,7 @@ export type DependenciesResolution = {
 export type Store = {
   pnpm: string,
   type: TreeType,
+  preserveSymlinks: boolean,
   packages: StorePackageMap
 }
 
@@ -32,6 +34,7 @@ export function create (treeType: TreeType): Store {
   return {
     pnpm: pnpmPkgJson.version,
     type: treeType,
+    preserveSymlinks,
     packages: {}
   }
 }

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -45,6 +45,7 @@ export type PackageSpec = {
 
 export type InstalledPackage = {
   pkg: Package,
+  path: string,
   optional: boolean,
   id: string,
   keypath: string[],
@@ -131,6 +132,7 @@ export default async function install (ctx: InstallContext, pkgMeta: PackageMeta
         name: spec.name,
         fromCache: false,
         dependencies: installedPkgs,
+        path: path.join(target, '_'),
       }
       log('package.json', pkg)
     }
@@ -191,6 +193,7 @@ export default async function install (ctx: InstallContext, pkgMeta: PackageMeta
         name: spec.name,
         fromCache: true,
         dependencies: [],
+        path: fullpath,
       }
     }
   }

--- a/src/install/linkPeers.ts
+++ b/src/install/linkPeers.ts
@@ -49,3 +49,42 @@ export default async function linkPeers (store: string, installs: InstalledPacka
       path.join(modules, peers[name].name))
   }))
 }
+
+type PackageVersions = {
+  [version: string]: InstalledPackage
+}
+
+type InstalledPackageVersions = {
+  [pkgName: string]: PackageVersions
+}
+
+export async function linkPeersWhenSymlinksPreserved (store: string, installs: InstalledPackages) {
+  if (!installs) return
+
+  const groupedPkgs: InstalledPackageVersions = {}
+
+  Object.keys(installs).forEach(id => {
+    const pkgData = installs[id]
+    if (!pkgData.pkg.version) return
+
+    const pkgName = pkgData.pkg.name
+    groupedPkgs[pkgName] = groupedPkgs[pkgName] || {}
+    groupedPkgs[pkgName][pkgData.pkg.version] = pkgData
+  })
+
+  return Promise.all(Object.keys(installs).map(id => {
+    const pkgData = installs[id]
+    const peerDependencies = pkgData.pkg.peerDependencies || {}
+    return Promise.all(Object.keys(peerDependencies).map(peerName => {
+      const version = semver.maxSatisfying(Object.keys(groupedPkgs[peerName]), peerDependencies[peerName], true)
+      if (!version) {
+        console.warn(`${pkgData.id} requires a peer of ${peerName}@${peerDependencies[peerName]} but none was installed.`)
+        return
+      }
+      return linkDir(
+        groupedPkgs[peerName][version].path,
+        path.join(pkgData.path, 'node_modules', peerName)
+      )
+    }))
+  }))
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export type Package = {
   dependencies?: Dependencies,
   devDependencies?: Dependencies,
   optionalDependencies?: Dependencies,
+  peerDependencies?: Dependencies,
   scripts?: {
     [name: string]: string
   }

--- a/test/install.ts
+++ b/test/install.ts
@@ -368,6 +368,10 @@ test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & 
 })
 
 test('flattening symlinks (minimatch@3.0.0)', async function (t) {
+  if (preserveSymlinks) {
+    t.skip('this is required only for Node.JS < 6.3.0')
+    return
+  }
   prepare()
   await installPkgs(['minimatch@3.0.0'], testDefaults())
 


### PR DESCRIPTION
This is a breaking change but no notification added because 0.42 wasn't published as latest yet.

Peer dependencies are just installed as regular dependencies. I am not a big fan of peer dependencies and I am OK if someone will rewrite this solution in the future. However, this seems to solve one of the angular issues described in #403, so I propose to merge it and work on the other issues.

About the breaking change: a different store is used for packages installed without the preserve-symlinks node feature. The reason for that is that newer Node does not require the hack with moving the packages around in the store, see line 131 in `api/install.ts`

Close #433