### PR TITLE
When links are not preserved, set NODE_PATH for binstubs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/rc": "0.0.1",
     "@types/semver": "5.3.30",
     "@types/update-notifier": "0.0.28",
-    "@zkochan/cmd-shim": "2.1.0",
+    "@zkochan/cmd-shim": "2.2.0",
     "@zkochan/logger": "0.1.0",
     "arr-flatten": "1.0.1",
     "byline": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/rc": "0.0.1",
     "@types/semver": "5.3.30",
     "@types/update-notifier": "0.0.28",
-    "@zkochan/cmd-shim": "2.0.1",
+    "@zkochan/cmd-shim": "2.1.0",
     "@zkochan/logger": "0.1.0",
     "arr-flatten": "1.0.1",
     "byline": "5.0.0",

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -93,6 +93,7 @@ async function installInContext (installType: string, packagesToInstall: Depende
       tag: opts.tag,
       engineStrict: opts.engineStrict,
       nodeVersion: opts.nodeVersion,
+      preserveSymlinks: opts.preserveSymlinks,
       got: createGot(client, {
         cachePath: ctx.cache,
         cacheTTL: opts.cacheTTL

--- a/src/api/link.ts
+++ b/src/api/link.ts
@@ -17,7 +17,7 @@ export async function linkFromRelative (linkTo: string, maybeOpts?: PnpmOptions)
   await mkdirp(currentModules)
   const pkg = await readPkgUp({ cwd: linkedPkgPath })
   await linkDir(linkedPkgPath, path.resolve(currentModules, pkg.pkg.name))
-  return linkPkgBins(currentModules, linkedPkgPath)
+  return linkPkgBins(currentModules, linkedPkgPath, opts.preserveSymlinks)
 }
 
 export function linkFromGlobal (pkgName: string, maybeOpts?: PnpmOptions) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,1 @@
-import semver = require('semver')
-
-export const preserveSymlinks = semver.satisfies(process.version, '>=6.3.0')
 export const isWindows = process.platform === 'win32'

--- a/src/install/installMultiple.ts
+++ b/src/install/installMultiple.ts
@@ -20,6 +20,7 @@ export type InstallOptions = FetchOptions & {
   engineStrict: boolean,
   nodeVersion: string,
   nodeModulesStore: string,
+  preserveSymlinks: boolean,
 }
 
 export type MultipleInstallOpts = InstallOptions & {
@@ -65,7 +66,7 @@ export default async function installAll (ctx: InstallContext, dependencies: Dep
         await linkDir(subdep.hardlinkedLocation, dest)
       })
   )
-  await linkBins(modules)
+  await linkBins(modules, options.preserveSymlinks)
 
   return installedPkgs
 }

--- a/src/install/linkBins.ts
+++ b/src/install/linkBins.ts
@@ -6,13 +6,13 @@ import mkdirp from '../fs/mkdirp'
 import requireJson from '../fs/requireJson'
 import getPkgDirs from '../fs/getPkgDirs'
 import binify from '../binify'
-import {isWindows, preserveSymlinks} from '../env'
+import {isWindows} from '../env'
 import cmdShim = require('@zkochan/cmd-shim')
 import {Package} from '../types'
 
-export default async function linkAllBins (modules: string) {
+export default async function linkAllBins (modules: string, preserveSymlinks: boolean) {
   const pkgDirs = await getPkgDirs(modules)
-  return Promise.all(pkgDirs.map((pkgDir: string) => linkPkgBins(modules, pkgDir)))
+  return Promise.all(pkgDirs.map((pkgDir: string) => linkPkgBins(modules, pkgDir, preserveSymlinks)))
 }
 
 /**
@@ -28,7 +28,7 @@ export default async function linkAllBins (modules: string) {
  *
  *     // node_modules/.bin/rimraf -> ../.store/rimraf@2.5.1/cmd.js
  */
-export async function linkPkgBins (modules: string, target: string) {
+export async function linkPkgBins (modules: string, target: string, preserveSymlinks: boolean) {
   const pkg = await safeRequireJson(path.join(target, 'package.json'))
 
   if (!pkg) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type PnpmOptions = {
   depth?: number,
   engineStrict?: boolean,
   nodeVersion?: string,
+  preserveSymlinks?: boolean,
 
   // proxy
   proxy?: string,
@@ -63,6 +64,7 @@ export type StrictPnpmOptions = {
   depth: number,
   engineStrict: boolean,
   nodeVersion: string,
+  preserveSymlinks: boolean,
 
   // proxy
   proxy?: string,

--- a/test/install.ts
+++ b/test/install.ts
@@ -535,7 +535,7 @@ test('fail when trying to install and uninstall from the same store simultaneous
   ])
 })
 
-test('packages should find the plugins they use when symlinks are preserved', async function (t) {
+test('top-level packages should find the plugins they use', async function (t) {
   const project = prepare(t, {
     scripts: {
       test: 'pkg-that-uses-plugins'
@@ -545,6 +545,19 @@ test('packages should find the plugins they use when symlinks are preserved', as
   const result = spawnSync('npm', ['test'])
   t.ok(result.stdout.toString().indexOf('My plugin is plugin-example') !== -1, 'package executable have found its plugin')
   t.equal(result.status, 0, 'executable exited with success')
+})
+
+test('not top-level packages should find the plugins they use', async function (t) {
+  // standard depends on eslint and eslint plugins
+  const project = prepare(t, {
+    scripts: {
+      test: 'standard'
+    }
+  })
+  await installPkgs(['standard@8.6.0'], testDefaults({ save: true }))
+  const result = spawnSync('npm', ['test'])
+  console.log(result.stdout.toString())
+  t.equal(result.status, 0, 'standard exited with success')
 })
 
 test('run js bin file', async function (t) {


### PR DESCRIPTION
This solves lots of issues that pnpm currently has on Node.js 4. Hopefully it also allows the usage of pnpm without the `--preserve-symlinks` option.

Ref #527

Most of the magic was done in cmd-shim [here](https://github.com/zkochan/cmd-shim/commit/68dc8ce2fc18228fd958940921ec121d70add6dc)