### PR TITLE
fix: make fetch atomic

### DIFF
--- a/src/install/fetch.ts
+++ b/src/install/fetch.ts
@@ -167,13 +167,25 @@ type FetchToStoreOptions = {
  */
 function fetchToStoreCached (opts: FetchToStoreOptions): Promise<void> {
   return memoize(opts.fetchLocks, opts.resolution.id, async function () {
-    if (opts.force || !await exists(opts.target)) {
-      await rimraf(opts.target)
+    const target = opts.target
+    const targetStage = `${opts.target}-stage`
+    const targetExists = await exists(target)
+    if (opts.force || !targetExists) {
+      // We fetch into targetStage directory first and then fs.rename() it to the
+      // target directory.
+
+      await rimraf(targetStage)
+      if (targetExists) {
+        await rimraf(target)
+      }
 
       logStatus({status: 'download-queued', pkg: opts.loggedPkg})
-      await fetchRes(opts.resolution, opts.target, {got: opts.got, loggedPkg: opts.loggedPkg})
-    }
+      await fetchRes(opts.resolution, targetStage, {got: opts.got, loggedPkg: opts.loggedPkg})
 
-    const pkg = await requireJson(path.join(opts.target, 'package.json'))
+      // fs.rename(oldPath, newPath) is an atomic operation, so we do it at the
+      // end
+      await fs.rename(targetStage, target)
+    }
+    const pkg = await requireJson(path.join(target, 'package.json'))
   })
 }


### PR DESCRIPTION
We fetch into a temp directory now and then fs.rename() into the target dir.
With fs.rename() being an atomic operation we don't leave target dir in an
inconsistent state if failure happen in some parallel installation process.

Fixes #547 