### PR TITLE
fix: make fetch atomic

### DIFF
--- a/test/install.ts
+++ b/test/install.ts
@@ -812,24 +812,6 @@ test('should not throw error if using a different store after all the packages w
   // TODO: implement
 })
 
-test('should reinstall package to the store if it is not in the store.yml', async function (t) {
-  // TODO: review, might fail sometimes
-  const project = prepare(t)
-
-  const opts = testDefaults()
-
-  try {
-    await installPkgs(['is-positive@3.1.0', 'this-pkg-does-not-exist-3f49f4'], opts)
-    t.fail('installation should have failed')
-  } catch (err) {}
-
-  await rimraf(opts.storePath)
-
-  await installPkgs(['is-positive@3.1.0'], opts)
-
-  t.ok(await exists(await project.resolve('is-positive', '3.1.0', 'index.js')))
-})
-
 test('shrinkwrap locks npm dependencies', async function (t) {
   const project = prepare(t)
 


### PR DESCRIPTION
We fetch into a temp directory now and then fs.rename() into the target dir.
With fs.rename() being an atomic operation we don't leave target dir in an
inconsistent state if failure happen in some parallel installation process.

Supersedes #549 
Fixes #547 