### PR TITLE
perf(git-resolver): try the GitHub API first to resolve git deps

### DIFF
--- a/src/resolve/git.ts
+++ b/src/resolve/git.ts
@@ -1,25 +1,61 @@
 import execa = require('execa')
-import {PackageSpec, ResolveOptions, ResolveResult} from '.'
+import {PackageSpec, HostedPackageSpec, ResolveOptions, ResolveResult} from '.'
 import {delimiter} from './createPkgId'
 import hostedGitInfo = require('@zkochan/hosted-git-info')
+import logger from 'pnpm-logger'
+import path = require('path')
+import {Got} from '../network/got'
 
-// TODO: resolve ref to commit
+const gitLogger = logger('git-logger')
+
+let tryGitHubApi = true
+
 export default async function resolveGit (parsedSpec: PackageSpec, opts: ResolveOptions): Promise<ResolveResult> {
+  const hspec = <HostedPackageSpec>parsedSpec
+  const isGitHubHosted = parsedSpec.type === 'hosted' && hspec.hosted.type === 'github'
   const parts = normalizeRepoUrl(parsedSpec.spec).split('#')
   const repo = parts[0]
   const ref = parts[1] || 'master'
-  const commitId = await resolveRef(repo, ref)
+
+  if (!isGitHubHosted || isSsh(parsedSpec.spec)) {
+    const commitId = await resolveRef(repo, ref)
+    return {
+      id: repo
+        .replace(/^.*:\/\/(git@)?/, '')
+        .replace(/:/g, delimiter)
+        .replace(/\.git$/, '') + '/' + commitId,
+      repo,
+      commitId,
+    }
+  }
+
+  const ghSpec = parseGithubSpec(hspec)
+  let commitId: string
+  if (tryGitHubApi) {
+    try {
+      commitId = await tryResolveViaGitHubApi(ghSpec, opts.got)
+    } catch (err) {
+      gitLogger.warn({
+        message: `Error while trying to resolve ${parsedSpec.spec} via GitHub API`,
+        err,
+      })
+
+      // if it fails once, don't bother retrying for other packages
+      tryGitHubApi = false
+
+      commitId = await resolveRef(repo, ref)
+    }
+  } else {
+    commitId = await resolveRef(repo, ref)
+  }
+
   return {
-    id: repo
-      .replace(/^.*:\/\/(git@)?/, '')
-      .replace(/:/g, delimiter)
-      .replace(/\.git$/, '') + '/' + commitId,
-    repo,
-    commitId,
+    id: path.join('github.com', ghSpec.owner, ghSpec.repo, commitId),
+    tarball: `https://codeload.github.com/${ghSpec.owner}/${ghSpec.repo}/tar.gz/${commitId}`
   }
 }
 
-async function resolveRef(repo: string, ref: string) {
+async function resolveRef (repo: string, ref: string) {
   const result = await execa('git', ['ls-remote', '--refs', repo, ref])
   // should output something like:
   //   572bc3d4e16220c2e986091249e62a5913294b25    	refs/heads/master
@@ -27,11 +63,54 @@ async function resolveRef(repo: string, ref: string) {
   // if no ref was found, assume that ref is the commit ID
   if (!result.stdout) return ref
 
-  return result.stdout.match(/^[a-z0-9]+/)
+  return result.stdout.match(/^[a-z0-9]+/)[0]
 }
 
 function normalizeRepoUrl (repoUrl: string) {
   const hosted = hostedGitInfo.fromUrl(repoUrl)
   if (!hosted) return repoUrl
   return hosted.getDefaultRepresentation() == 'shortcut' ? hosted.git() : hosted.toString()
+}
+
+function isSsh (gitSpec: string): boolean {
+  return gitSpec.substr(0, 10) === 'git+ssh://'
+    || gitSpec.substr(0, 4) === 'git@'
+}
+
+/**
+ * Resolves a 'hosted' package hosted on 'github'.
+ */
+async function tryResolveViaGitHubApi (spec: GitHubSpec, got: Got) {
+  const url = [
+    'https://api.github.com/repos',
+    spec.owner,
+    spec.repo,
+    'commits',
+    spec.ref
+  ].join('/')
+  const body = await got.getJSON<GitHubRepoResponse>(url)
+  return body.sha
+}
+
+const PARSE_GITHUB_RE = /^github:([^\/]+)\/([^#]+)(#(.+))?$/
+
+function parseGithubSpec (spec: HostedPackageSpec): GitHubSpec {
+  const m = PARSE_GITHUB_RE.exec(spec.hosted.shortcut)
+  if (!m) {
+    throw new Error('cannot parse: ' + spec.hosted.shortcut)
+  }
+  const owner = m[1]
+  const repo = m[2]
+  const ref = m[4] || 'HEAD'
+  return {owner, repo, ref}
+}
+
+type GitHubSpec = {
+  owner: string,
+  repo: string,
+  ref: string
+}
+
+type GitHubRepoResponse = {
+  sha: string
 }

--- a/src/resolve/index.ts
+++ b/src/resolve/index.ts
@@ -73,8 +73,3 @@ export default function (spec: PackageSpec, opts: ResolveOptions): Promise<Resol
       throw new Error(`${spec.rawSpec}: ${spec.type} packages not supported`)
   }
 }
-
-function isSsh (gitSpec: string): boolean {
-  return gitSpec.substr(0, 10) === 'git+ssh://'
-    || gitSpec.substr(0, 4) === 'git@'
-}


### PR DESCRIPTION
Try the GitHub API first to resolve git deps. If fails due to
API limit, fall back to `git ls-remote`.

Always use codeload to download deps from GitHub.

Close #536