### PR TITLE
Global bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ Use `pnpm` in place of `npm`. It overrides `pnpm i`, `pnpm install` and some oth
 pnpm install lodash
 ```
 
-For using globally installed packages, see: [global install](docs/global-install.md).
-
 For using the programmatic API, see: [API](docs/api.md).
 
 ## Benchmark

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,6 @@
 * Features
   * [Custom registries](custom-registries.md)
   * [Store layout](store-layout.md)
-  * [Global install](global-install.md)
 * Comparison
   * [npm](vs-npm.md)
   * [ied](vs-ied.md)

--- a/docs/global-install.md
+++ b/docs/global-install.md
@@ -1,4 +1,0 @@
-# Global install
-
-`pnpm` uses a "global package" to install the global dependencies. The global package is situated at `~/.pnpm`.
-In order to use globally installed packages as executables, you can add `~/.pnpm/node_modules/.bin` to your `PATH`.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "execa": "0.6.0",
     "exists-file": "3.0.0",
     "find-up": "2.1.0",
+    "global-bin-path": "0.1.0",
     "is-ci": "1.0.10",
     "is-retry-allowed": "1.1.0",
     "is-windows": "1.0.0",

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -1,14 +1,8 @@
-import path = require('path')
 import rimraf = require('rimraf-then')
-import {DEFAULT_GLOBAL_PATH} from './constantDefaults'
 import expandTilde from '../fs/expandTilde'
 
-export function cleanCache (globalPath?: string) {
-  globalPath = globalPath || DEFAULT_GLOBAL_PATH
-  const cachePath = getCachePath(globalPath)
-  return rimraf(cachePath)
-}
+export const CACHE_PATH = expandTilde('~/.pnpm-cache')
 
-export function getCachePath (globalPath: string) {
-  return path.join(expandTilde(globalPath), 'cache')
+export function cleanCache (cachePath?: string) {
+  return rimraf(expandTilde(cachePath || CACHE_PATH))
 }

--- a/src/api/constantDefaults.ts
+++ b/src/api/constantDefaults.ts
@@ -1,1 +1,0 @@
-export const DEFAULT_GLOBAL_PATH = '~/.pnpm'

--- a/src/api/extendOptions.ts
+++ b/src/api/extendOptions.ts
@@ -1,7 +1,11 @@
 import {StrictPnpmOptions, PnpmOptions} from '../types'
-import {DEFAULT_GLOBAL_PATH} from './constantDefaults'
+import globalBinPath = require('global-bin-path')
+import path = require('path')
 import semver = require('semver')
 import logger from 'pnpm-logger'
+import {CACHE_PATH} from './cache'
+
+const DEFAULT_GLOBAL_PATH = path.join(globalBinPath(), 'pnpm')
 
 const CAN_PRESERVE_SYMLINKS = semver.satisfies(process.version, '>=6.3.0')
 
@@ -11,6 +15,7 @@ const defaults = () => (<StrictPnpmOptions>{
   fetchRetryMintimeout: 1e4, // 10 seconds
   fetchRetryMaxtimeout: 6e4, // 1 minute
   storePath: '~/.pnpm-store',
+  cachePath: CACHE_PATH,
   globalPath: DEFAULT_GLOBAL_PATH,
   ignoreScripts: false,
   linkLocal: false,

--- a/src/api/extendOptions.ts
+++ b/src/api/extendOptions.ts
@@ -5,7 +5,7 @@ import semver = require('semver')
 import logger from 'pnpm-logger'
 import {CACHE_PATH} from './cache'
 
-const DEFAULT_GLOBAL_PATH = path.join(globalBinPath(), 'pnpm')
+const DEFAULT_GLOBAL_PATH = path.join(globalBinPath(), 'pnpm-global')
 
 const CAN_PRESERVE_SYMLINKS = semver.satisfies(process.version, '>=6.3.0')
 

--- a/src/api/getContext.ts
+++ b/src/api/getContext.ts
@@ -20,7 +20,6 @@ import {
 } from '../fs/modulesController'
 import mkdirp from '../fs/mkdirp'
 import {Package} from '../types'
-import {getCachePath} from './cache'
 import normalizePath = require('normalize-path')
 
 export type PnpmContext = {
@@ -71,7 +70,7 @@ export default async function (opts: StrictPnpmOptions): Promise<PnpmContext> {
   const ctx: PnpmContext = {
     pkg: pkg.pkg,
     root,
-    cache: getCachePath(opts.globalPath),
+    cache: expandTilde(opts.cachePath),
     storePath,
     graph,
     shrinkwrap,

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -4,6 +4,7 @@ import seq = require('promisequence')
 import RegClient = require('npm-registry-client')
 import logger from 'pnpm-logger'
 import cloneDeep = require('lodash.clonedeep')
+import globalBinPath = require('global-bin-path')
 import {PnpmOptions, StrictPnpmOptions, Dependencies} from '../types'
 import createGot from '../network/got'
 import getContext, {PnpmContext} from './getContext'
@@ -93,6 +94,7 @@ async function installInContext (installType: string, packagesToInstall: Depende
       }),
       fetchingFiles: Promise.resolve(),
       nodeModulesStore: path.join(nodeModulesPath, '.resolutions'),
+      binPath: opts.global ? globalBinPath() : path.join(nodeModulesPath, '.bin'),
     }
     return await installMultiple(
       installCtx,

--- a/src/api/link.ts
+++ b/src/api/link.ts
@@ -17,7 +17,8 @@ export async function linkFromRelative (linkTo: string, maybeOpts?: PnpmOptions)
   await mkdirp(currentModules)
   const pkg = await readPkgUp({ cwd: linkedPkgPath })
   await linkDir(linkedPkgPath, path.resolve(currentModules, pkg.pkg.name))
-  return linkPkgBins(currentModules, linkedPkgPath, opts.preserveSymlinks)
+  const bin = path.join(currentModules, '.bin')
+  return linkPkgBins(linkedPkgPath, bin, opts.preserveSymlinks)
 }
 
 export function linkFromGlobal (pkgName: string, maybeOpts?: PnpmOptions) {

--- a/src/cmd/cache.ts
+++ b/src/cmd/cache.ts
@@ -5,5 +5,5 @@ export default function (input: string[], opts: PnpmOptions) {
   if (input.length !== 1 || input[0] !== 'clean') {
     throw new Error('Currently only the `cache clean` command is supported')
   }
-  return cleanCache(opts.globalPath)
+  return cleanCache(opts.cachePath)
 }

--- a/src/install/installMultiple.ts
+++ b/src/install/installMultiple.ts
@@ -29,7 +29,8 @@ export type InstallOptions = FetchOptions & {
 }
 
 export type MultipleInstallOpts = InstallOptions & {
-  fetchingFiles: Promise<void>
+  fetchingFiles: Promise<void>,
+  binPath: string,
 }
 
 export type InstalledPackage = FetchedPackage & {
@@ -69,7 +70,7 @@ export default async function installAll (ctx: InstallContext, dependencies: Dep
         await linkDir(subdep.hardlinkedLocation, dest)
       })
   )
-  await linkBins(modules, path.join(modules, '.bin'), options.preserveSymlinks)
+  await linkBins(modules, options.binPath, options.preserveSymlinks)
 
   return installedPkgs
 }
@@ -215,6 +216,7 @@ async function installDependencies (pkg: Package, dependency: InstalledPackage, 
     dependent: dependency.id,
     root: dependency.srcPath,
     fetchingFiles: dependency.fetchingFiles,
+    binPath: path.join(modules, '.bin'),
   })
 
   const bundledDeps = pkg.bundleDependencies || pkg.bundleDependencies || []

--- a/src/install/installMultiple.ts
+++ b/src/install/installMultiple.ts
@@ -69,7 +69,7 @@ export default async function installAll (ctx: InstallContext, dependencies: Dep
         await linkDir(subdep.hardlinkedLocation, dest)
       })
   )
-  await linkBins(modules, options.preserveSymlinks)
+  await linkBins(modules, path.join(modules, '.bin'), options.preserveSymlinks)
 
   return installedPkgs
 }

--- a/src/install/linkBins.ts
+++ b/src/install/linkBins.ts
@@ -67,7 +67,11 @@ function makeExecutable (filePath: string) {
   return fs.chmod(filePath, 0o755)
 }
 
-async function proxy (proxyPath: string, relTargetPath: string) {
+async function proxy (proxyPath: string, relTargetPath: string): Promise<void> {
+  if (!relTargetPath.startsWith('.')) {
+    // require should always be identified as relative by Node
+    return proxy(proxyPath, `./${relTargetPath}`)
+  }
   // NOTE: this will be used only on non-windows
   // Hence, the \n line endings should be used
   const proxyContent = '#!/bin/sh\n' +

--- a/src/install/linkBins.ts
+++ b/src/install/linkBins.ts
@@ -13,25 +13,15 @@ import logger from 'pnpm-logger'
 
 const IS_WINDOWS = isWindows()
 
-export default async function linkAllBins (modules: string, preserveSymlinks: boolean) {
+export default async function linkAllBins (modules: string, binDir: string, preserveSymlinks: boolean) {
   const pkgDirs = await getPkgDirs(modules)
-  return Promise.all(pkgDirs.map((pkgDir: string) => linkPkgBins(modules, pkgDir, preserveSymlinks)))
+  return Promise.all(pkgDirs.map((pkgDir: string) => linkPkgBins(pkgDir, binDir, preserveSymlinks)))
 }
 
 /**
  * Links executable into `node_modules/.bin`.
- *
- * @param {String} modules - the node_modules path
- * @param {String} target - where the module is now; read package.json from here
- *
- * @example
- *     module = 'project/node_modules'
- *     target = 'project/node_modules/.store/rimraf@2.5.1'
- *     linkPkgBins(module, target)
- *
- *     // node_modules/.bin/rimraf -> ../.store/rimraf@2.5.1/cmd.js
  */
-export async function linkPkgBins (modules: string, target: string, preserveSymlinks: boolean) {
+export async function linkPkgBins (target: string, binDir: string, preserveSymlinks: boolean) {
   const pkg = await safeRequireJson(path.join(target, 'package.json'))
 
   if (!pkg) {
@@ -42,7 +32,6 @@ export async function linkPkgBins (modules: string, target: string, preserveSyml
   if (!pkg.bin) return
 
   const bins = binify(pkg)
-  const binDir = path.join(modules, '.bin')
 
   await mkdirp(binDir)
   await Promise.all(Object.keys(bins).map(async function (bin) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type PnpmOptions = {
   global?: boolean,
   globalPath?: string,
   storePath?: string,
+  cachePath?: string,
   ignoreScripts?: boolean
   save?: boolean,
   saveDev?: boolean,
@@ -45,6 +46,7 @@ export type StrictPnpmOptions = {
   global: boolean,
   globalPath: string,
   storePath: string,
+  cachePath: string,
   ignoreScripts: boolean
   save: boolean,
   saveDev: boolean,

--- a/test/cache.ts
+++ b/test/cache.ts
@@ -16,13 +16,11 @@ test('cache clean removes cache', async function (t) {
 
   await installPkgs(['is-positive'], opts)
 
-  const cache = path.join(opts.globalPath, 'cache')
+  t.ok(await exists(opts.cachePath), 'cache is created')
 
-  t.ok(await exists(cache), 'cache is created')
+  await cleanCache(opts.cachePath)
 
-  await cleanCache(opts.globalPath)
-
-  t.ok(!await exists(cache), 'cache is removed')
+  t.ok(!await exists(opts.cachePath), 'cache is removed')
 })
 
 test('should fail to update when requests are cached', async function (t) {

--- a/test/support/testDefaults.ts
+++ b/test/support/testDefaults.ts
@@ -4,6 +4,7 @@ import path = require('path')
 export default function testDefaults (opts?: PnpmOptions): PnpmOptions & {globalPath: string, storePath: string} {
   return Object.assign({
     storePath: path.join(process.cwd(), '..', '.store'),
+    cachePath: path.join(process.cwd(), '..', '.cache'),
     registry: 'http://localhost:4873/',
     globalPath: path.join(process.cwd(), '..', 'global'),
   }, opts)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,9 +23,7 @@
   },
   "files": [
     "src/api/cache.ts",
-    "src/api/constantDefaults.ts",
     "src/api/extendOptions.ts",
-    "src/api/getCachePath.ts",
     "src/api/getContext.ts",
     "src/api/index.ts",
     "src/api/install.ts",

--- a/typings/local.d.ts
+++ b/typings/local.d.ts
@@ -222,3 +222,8 @@ declare module '@zkochan/hosted-git-info' {
   const anything: any;
   export = anything;
 }
+
+declare module 'global-bin-path' {
+  const anything: any;
+  export = anything;
+}


### PR DESCRIPTION
To make global CLIs work without any additional configuration, link bins to a directory which is already in the system path.

- [x] test on Windows
- [x] test on Linux
- [x] test on OSX